### PR TITLE
Correct usage of Postgres and Null values

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,24 +22,20 @@ function decodeFromDialect(dialect, content, model) {
     }
 
     const decodedValues = content.toJSON();
+    const fields = model.base.describe().children;
 
-    // Convert non-postgres complex values
-    if (dialect !== 'postgres') {
-        const fields = model.base.describe().children;
+    Object.keys(decodedValues).forEach((fieldName) => {
+        const field = fields[fieldName] || {};
+        const fieldType = field.type;
 
-        Object.keys(decodedValues).forEach((fieldName) => {
-            const field = fields[fieldName] || {};
-            const fieldType = field.type;
+        if (fieldType === 'array' || fieldType === 'object') {
+            decodedValues[fieldName] = JSON.parse(decodedValues[fieldName]);
+        }
 
-            if (fieldType === 'array' || fieldType === 'object') {
-                decodedValues[fieldName] = JSON.parse(decodedValues[fieldName]);
-            }
-
-            if (decodedValues[fieldName] === null) {
-                delete decodedValues[fieldName];
-            }
-        });
-    }
+        if (decodedValues[fieldName] === null) {
+            delete decodedValues[fieldName];
+        }
+    });
 
     return Promise.resolve(decodedValues);
 }
@@ -64,19 +60,16 @@ function encodeToDialect(dialect, content, model) {
             encodedObject[keyName] = promisedValues[index];
         });
 
-        // Convert non-postgres complex values
-        if (dialect !== 'postgres') {
-            const fields = model.base.describe().children;
+        const fields = model.base.describe().children;
 
-            encodedKeys.forEach((fieldName) => {
-                const field = fields[fieldName] || {};
-                const fieldType = field.type;
+        encodedKeys.forEach((fieldName) => {
+            const field = fields[fieldName] || {};
+            const fieldType = field.type;
 
-                if (fieldType === 'array' || fieldType === 'object') {
-                    encodedObject[fieldName] = JSON.stringify(encodedObject[fieldName]);
-                }
-            });
-        }
+            if (fieldType === 'array' || fieldType === 'object') {
+                encodedObject[fieldName] = JSON.stringify(encodedObject[fieldName]);
+            }
+        });
 
         return encodedObject;
     });
@@ -92,6 +85,8 @@ function encodeToDialect(dialect, content, model) {
 function getSequelizeTypeFromJoi(dialect, type) {
     switch (type) {
     case 'string':
+    case 'array':
+    case 'object':
         return Sequelize.TEXT;
     case 'date':
         return Sequelize.DATE;
@@ -101,12 +96,6 @@ function getSequelizeTypeFromJoi(dialect, type) {
         return Sequelize.BOOLEAN;
     case 'binary':
         return Sequelize.BLOB;
-    case 'array':
-        // Unique to postgres, so JSON stringify for others
-        return dialect === 'postgres' ? Sequelize.ARRAY(Sequelize.TEXT) : Sequelize.TEXT;
-    case 'object':
-        // Unique to postgres, so JSON stringify for others
-        return dialect === 'postgres' ? Sequelize.JSON : Sequelize.TEXT;
     default:
         return null;
     }

--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ function decodeFromDialect(dialect, content, model) {
             if (fieldType === 'array' || fieldType === 'object') {
                 decodedValues[fieldName] = JSON.parse(decodedValues[fieldName]);
             }
+
+            if (decodedValues[fieldName] === null) {
+                delete decodedValues[fieldName];
+            }
         });
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -230,7 +230,8 @@ describe('index test', () => {
                 id: 'data',
                 key: 'value',
                 arr: '[1,2,3]',
-                obj: '{"a":"b"}'
+                obj: '{"a":"b"}',
+                bar: null
             };
             const realData = {
                 id: 'data',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -152,52 +152,6 @@ describe('index test', () => {
             });
         });
 
-        it('constructs the clients special for postgres', () => {
-            sequelizeClientMock.getDialect.returns('postgres');
-            datastore = new Datastore({
-                dialect: 'postgres'
-            });
-            assert.calledWith(sequelizeClientMock.define, 'jobs', {
-                id: {
-                    type: 'TEXT',
-                    primaryKey: true
-                },
-                name: {
-                    type: 'TEXT'
-                }
-            });
-            assert.calledWith(sequelizeClientMock.define, 'pipelines', {
-                id: {
-                    type: 'TEXT',
-                    primaryKey: true
-                },
-                str: {
-                    type: 'TEXT'
-                },
-                date: {
-                    type: 'DATE'
-                },
-                num: {
-                    type: 'DECIMAL'
-                },
-                bool: {
-                    type: 'BOOLEAN'
-                },
-                bin: {
-                    type: 'BLOB'
-                },
-                arr: {
-                    type: 'ARRAY'
-                },
-                obj: {
-                    type: 'JSON'
-                },
-                any: {
-                    type: null
-                }
-            });
-        });
-
         it('constructs the clients with a prefix', () => {
             datastore = new Datastore({
                 dialect: 'sqlite',
@@ -244,43 +198,6 @@ describe('index test', () => {
 
             sequelizeTableMock.findById.resolves(responseMock);
             responseMock.toJSON.returns(testData);
-
-            return datastore.get(testParams).then((data) => {
-                assert.deepEqual(data, realData);
-                assert.calledWith(sequelizeTableMock.findById, testParams.params.id);
-            });
-        });
-
-        it('gets data by id for postgres', () => {
-            const testParams = {
-                table: 'pipelines',
-                params: {
-                    id: 'someId'
-                }
-            };
-            const testData = {
-                id: 'data',
-                key: 'value',
-                arr: [1, 2, 3],
-                obj: {
-                    a: 'b'
-                }
-            };
-            const realData = {
-                id: 'data',
-                key: 'value',
-                arr: [1, 2, 3],
-                obj: {
-                    a: 'b'
-                }
-            };
-
-            sequelizeClientMock.getDialect.returns('postgres');
-            sequelizeTableMock.findById.resolves(responseMock);
-            responseMock.toJSON.returns(testData);
-            datastore = new Datastore({
-                dialect: 'postgres'
-            });
 
             return datastore.get(testParams).then((data) => {
                 assert.deepEqual(data, realData);
@@ -364,47 +281,6 @@ describe('index test', () => {
                     id: 'someIdToPutHere',
                     arr: '[1,2,3]',
                     obj: '{"a":"b"}'
-                });
-            });
-        });
-
-        it('saves the data for postgres', () => {
-            const expectedResult = {
-                id: 'someIdToPutHere',
-                key: 'value',
-                arr: [1, 2, 3],
-                obj: {
-                    a: 'b'
-                }
-            };
-
-            sequelizeTableMock.create.resolves();
-            sequelizeClientMock.getDialect.returns('postgres');
-            datastore = new Datastore({
-                dialect: 'postgres'
-            });
-
-            return datastore.save({
-                table: 'pipelines',
-                params: {
-                    id: 'someIdToPutHere',
-                    data: {
-                        key: 'value',
-                        arr: [1, 2, 3],
-                        obj: {
-                            a: 'b'
-                        }
-                    }
-                }
-            }).then((data) => {
-                assert.deepEqual(data, expectedResult);
-                assert.calledWith(sequelizeTableMock.create, {
-                    key: 'value',
-                    id: 'someIdToPutHere',
-                    arr: [1, 2, 3],
-                    obj: {
-                        a: 'b'
-                    }
                 });
             });
         });


### PR DESCRIPTION
- Remove `null` values in returns as our validation considers it bad output.
- Removing special casing for Postgres as we use mixed array cases (not always string, sometimes object).