### PR TITLE
Use mysql instead of mysql2

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "sinon-as-promised": "^4.0.2"
   },
   "dependencies": {
-    "mysql2": "^1.1.1",
+    "mysql": "^2.11.1",
     "pg": "^6.1.0",
     "pg-hstore": "^2.3.2",
     "screwdriver-data-schema": "^14.0.0",


### PR DESCRIPTION
Currently `sequelize` requires mysql module not mysql2. 
screwdriver-cd/screwdriver#325