### PR TITLE
Use Sequelize.STRING with length

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,12 +84,8 @@ function encodeToDialect(dialect, content, model) {
  * @return {SequelizeType}           Type to use in Sequelize
  */
 function getSequelizeTypeFromJoi(dialect, type, rules) {
-    let length;
-
     // Get the column length if length/max rule is included in dataschema
-    if (rules) {
-        length = rules.filter(o => o.name === 'length' || o.name === 'max').map(o => o.arg)[0];
-    }
+    const length = rules.filter(o => o.name === 'length' || o.name === 'max').map(o => o.arg)[0];
 
     switch (type) {
     case 'string':
@@ -168,7 +164,11 @@ class Squeakquel extends Datastore {
         Object.keys(fields).forEach((fieldName) => {
             const field = fields[fieldName];
             const output = {
-                type: getSequelizeTypeFromJoi(this.client.getDialect(), field.type, field.rules)
+                type: getSequelizeTypeFromJoi(
+                    this.client.getDialect(),
+                    field.type,
+                    field.rules || []
+                )
             };
 
             if (fieldName === 'id') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,6 +40,7 @@ describe('index test', () => {
             getDialect: sinon.stub().returns('sqlite')
         };
         sequelizeMock = sinon.stub().returns(sequelizeClientMock);
+        sequelizeMock.STRING = sinon.stub().withArgs(40).returns('VARCHAR(40)');
         sequelizeMock.TEXT = 'TEXT';
         sequelizeMock.DATE = 'DATE';
         sequelizeMock.DECIMAL = 'DECIMAL';
@@ -55,7 +56,7 @@ describe('index test', () => {
             models: {
                 pipeline: {
                     base: joi.object({
-                        id: joi.string(),
+                        id: joi.string().length(40),
                         str: joi.string(),
                         date: joi.date(),
                         num: joi.number(),
@@ -70,7 +71,7 @@ describe('index test', () => {
                 },
                 job: {
                     base: joi.object({
-                        id: joi.string(),
+                        id: joi.string().length(40),
                         name: joi.string()
                     }),
                     tableName: 'jobs',
@@ -113,7 +114,7 @@ describe('index test', () => {
             });
             assert.calledWith(sequelizeClientMock.define, 'jobs', {
                 id: {
-                    type: 'TEXT',
+                    type: 'VARCHAR(40)',
                     primaryKey: true
                 },
                 name: {
@@ -122,7 +123,7 @@ describe('index test', () => {
             });
             assert.calledWith(sequelizeClientMock.define, 'pipelines', {
                 id: {
-                    type: 'TEXT',
+                    type: 'VARCHAR(40)',
                     primaryKey: true
                 },
                 str: {


### PR DESCRIPTION
MySQL requires that an indexed column including primary key is fixed length.
Sequelize will generate a DDL with no length option if we specify `Sequelize.TEXT` as data type.
Screwdriver mainly uses string hash as ID, so the current version  doesn't work with MySQL. (screwdriver-cd/screwdriver#325)

This PR fixes this issue by using `Sequelize.STRING(len)` for fixed-length string column.
