### PR TITLE
feat(399): switch to numbers instead of hashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-sequelize",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Datastore implementation for mysql, postgres, sqlite3, and mssql",
   "main": "index.js",
   "scripts": {
@@ -40,7 +40,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.2.2",
     "eslint-config-screwdriver": "^2.0.0",
-    "jenkins-mocha": "^3.0.0",
+    "jenkins-mocha": "^4.0.0",
     "joi": "^10.0.5",
     "mockery": "^2.0.0",
     "sinon": "^1.17.4",
@@ -50,8 +50,8 @@
     "mysql": "^2.11.1",
     "pg": "^6.1.0",
     "pg-hstore": "^2.3.2",
-    "screwdriver-data-schema": "^15.0.3",
-    "screwdriver-datastore-base": "^2.2.0",
+    "screwdriver-data-schema": "^16.0.0",
+    "screwdriver-datastore-base": "^3.0.0",
     "sequelize": "^3.24.3",
     "sqlite3": "^3.1.6"
   }

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -1,0 +1,4 @@
+extends: screwdriver
+rules:
+    func-names: off
+    prefer-arrow-callback: off


### PR DESCRIPTION
- Lookup without ID if not provided
- Save no longer requires `id`
- Update takes new format
- Add auto-incrementing and unique keys

BREAKING CHANGE: Requires an improved input for save and update

Epic: https://github.com/screwdriver-cd/screwdriver/issues/399
Blocked By: 
 - https://github.com/screwdriver-cd/data-schema/pull/98 (merged)
 - https://github.com/screwdriver-cd/datastore-base/pull/24 (merged)