### PR TITLE
fix: change DECIMAL to DOUBLE

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function getSequelizeTypeFromJoi(dialect, type, rules) {
     case 'date':
         return Sequelize.DATE;
     case 'number':
-        return Sequelize.DECIMAL;
+        return Sequelize.DOUBLE;
     case 'boolean':
         return Sequelize.BOOLEAN;
     case 'binary':

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -82,7 +82,7 @@ describe('index test', function () {
         sequelizeMock.STRING = sinon.stub().withArgs(40).returns('VARCHAR(40)');
         sequelizeMock.TEXT = 'TEXT';
         sequelizeMock.DATE = 'DATE';
-        sequelizeMock.DECIMAL = 'DECIMAL';
+        sequelizeMock.DOUBLE = 'DOUBLE';
         sequelizeMock.INTEGER = {};
         sequelizeMock.INTEGER.UNSIGNED = 'UNSIGNED INTEGER';
         sequelizeMock.BOOLEAN = 'BOOLEAN';
@@ -152,7 +152,7 @@ describe('index test', function () {
                     type: 'DATE'
                 },
                 num: {
-                    type: 'DECIMAL',
+                    type: 'DOUBLE',
                     unique: 'uniquerow'
                 },
                 bool: {


### PR DESCRIPTION
Beta is currently failing because launcher fails to unmarshall. The eventId and jobId are string when we read back from datastore here: https://github.com/screwdriver-cd/datastore-sequelize/blob/master/index.js#L348 

![screen shot 2016-12-29 at 2 26 34 pm](https://cloud.githubusercontent.com/assets/3401924/21556136/ee76e7c0-cdd2-11e6-9fe6-03c07062d69f.png)

Changing this to `DOUBLE` fixes it
<img width="402" alt="screen shot 2016-12-29 at 2 30 43 pm" src="https://cloud.githubusercontent.com/assets/3401924/21556194/6c2bbdd0-cdd3-11e6-9111-ba5854970c9c.png">

Related: https://github.com/screwdriver-cd/screwdriver/issues/399