### PR TITLE
feat: update to sequelize 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ class Squeakquel extends Datastore {
      * @return {Promise}
      */
     setup() {
-        return this.client.sync();
+        return this.client.sync({ alter: true });
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-sequelize",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Datastore implementation for mysql, postgres, sqlite3, and mssql",
   "main": "index.js",
   "scripts": {
@@ -37,22 +37,21 @@
     }
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "eslint": "^3.2.2",
-    "eslint-config-screwdriver": "^2.0.0",
-    "jenkins-mocha": "^4.0.0",
-    "joi": "^10.0.5",
+    "chai": "^4.0.2",
+    "eslint": "^3.19.0",
+    "eslint-config-screwdriver": "^2.1.3",
+    "jenkins-mocha": "^4.1.2",
+    "joi": "^10.5.2",
     "mockery": "^2.0.0",
-    "sinon": "^1.17.4",
-    "sinon-as-promised": "^4.0.2"
+    "sinon": "^2.3.2"
   },
   "dependencies": {
-    "mysql": "^2.11.1",
-    "pg": "^6.1.0",
+    "mysql": "^2.13.0",
+    "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
-    "screwdriver-data-schema": "^16.0.0",
-    "screwdriver-datastore-base": "^3.0.0",
-    "sequelize": "^3.24.3",
-    "sqlite3": "^3.1.6"
+    "screwdriver-data-schema": "^16.8.9",
+    "screwdriver-datastore-base": "^3.0.1",
+    "sequelize": "^4.0.0",
+    "sqlite3": "^3.1.8"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,8 +8,6 @@ const joi = require('joi');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-require('sinon-as-promised');
-
 describe('index test', function () {
     const dataSchemaMock = {
         models: {


### PR DESCRIPTION
Context:
========
Sequelize 4.x adds a feature to do `ALTER TABLE` when performing a `sync()`. This should allow us to dynamically update table columns.

Objective:
----------
Update sequelize so we can update tables without dropping and recreating them.