### PR TITLE
fix: Don't pass prefix config to Sequelize

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,13 +125,17 @@ class Squeakquel extends Datastore {
         super();
 
         config.logging = () => {};
+        this.prefix = config.prefix || '';
+
+        // It won't work if prefix is passed to Sequelize
+        delete config.prefix;
+
         this.client = new Sequelize(
             config.database || 'screwdriver',
             config.username,
             config.password,
             config
         );
-        this.prefix = config.prefix || '';
 
         this.tables = {};
         this.models = {};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -178,6 +178,7 @@ describe('index test', function () {
             });
             assert.calledWith(sequelizeClientMock.define, 'boo_jobs');
             assert.calledWith(sequelizeClientMock.define, 'boo_pipelines');
+            assert.isUndefined(sequelizeMock.lastCall.args[3].prefix);
         });
     });
 


### PR DESCRIPTION
I found that this module doesn't work with Sequelize@^4.0.0 when `prefix` is set.

There is a process which joins `prefix` and `column` with `.` in sequelize.
https://github.com/sequelize/sequelize/blob/v4.4.2/lib/dialects/abstract/query-generator.js#L2344

In v4.4.2, query generator in each dialect calls `whereQuery` with `options` which includes `prefix` key from dataschema-sequelize, so it generates a broken query like `WHERE myprefix_.id = 1`.
https://github.com/sequelize/sequelize/blob/v4.4.2/lib/dialects/sqlite/query-generator.js#L242
But v3.30.4 calls it without `options` object, so it generates a query like `WHERE id = 1`.
https://github.com/sequelize/sequelize/blob/v3.30.4/lib/dialects/sqlite/query-generator.js#L152

There is no document described about `prefix` option, so I've removed it from Sequelize config.

#### Related
- mentioned about new Sequelize: screwdriver-cd/screwdriver#633
- introduced new one: screwdriver-cd/screwdriver#648