### PR TITLE
Fix: Replace mysql with mysql2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "sinon": "^2.3.2"
   },
   "dependencies": {
-    "mysql": "^2.13.0",
+    "mysql2": "^1.4.2",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
     "screwdriver-data-schema": "^18.0.0",


### PR DESCRIPTION
Sequelize@4 was introduced by #18. It requires `mysql2` module instead of `mysql`.
I confirmed that `mysql2` module works well by customizing Dockerfile like below.
```
RUN cd /usr/src/app && npm install mysql2
```