### PR TITLE
fix: use semantic-release template

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -11,9 +11,7 @@ jobs:
             - test: npm test
 
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
`mysql2` is included in https://github.com/screwdriver-cd/datastore-sequelize/pull/23 but this package has not been published yet.