### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,7 +2,7 @@ workflow:
     - publish
 
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it.

## Objective

* Change image in `screwdriver.yaml` to `node:8`