### PR TITLE
feat(880): Allow sort by sortBy field [2]

### DIFF
--- a/index.js
+++ b/index.js
@@ -309,6 +309,7 @@ class Squeakquel extends Datastore {
      * @param  {Number}   [config.paginate.page]    Specific page of the set to return
      * @param  {Object}   [config.params]           index => values to query on
      * @param  {String}   [config.sort]             Sorting option based on GSI range key. Ascending or descending.
+     * @param  {String}   [config.sortBy]           Key to sort by; defaults to 'id'
      * @return {Promise}                            Resolves to an array of records
      */
     _scan(config) {
@@ -347,6 +348,10 @@ class Squeakquel extends Datastore {
                     sortKey = model.rangeKeys[indexIndex];
                 }
             });
+        }
+
+        if (config.sortBy) {
+            sortKey = config.sortBy;
         }
 
         if (config.sort === 'ascending') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -593,6 +593,44 @@ describe('index test', function () {
             });
         });
 
+        it('scans all the data and returns sorted by sortBy field', () => {
+            const testData = [
+                {
+                    id: 'data2',
+                    scmRepo: {
+                        name: 'A'
+                    },
+                    key: 'value2'
+                },
+                {
+                    id: 'data1',
+                    scmRepo: {
+                        name: 'B'
+                    },
+                    key: 'value1'
+                }
+            ];
+            const testInternal = [
+                {
+                    toJSON: sinon.stub().returns(testData[0])
+                },
+                {
+                    toJSON: sinon.stub().returns(testData[1])
+                }
+            ];
+
+            sequelizeTableMock.findAll.resolves(testInternal);
+            testParams.sortBy = 'scmRepo.name';
+
+            return datastore.scan(testParams).then((data) => {
+                assert.deepEqual(data, testData);
+                assert.calledWith(sequelizeTableMock.findAll, {
+                    where: {},
+                    order: [['scmRepo.name', 'DESC']]
+                });
+            });
+        });
+
         it('scans for some data with params', () => {
             const testData = [
                 {


### PR DESCRIPTION
## Context

Users should be able to specify which field they want to sort by when queries are returned from the DB.

## Objective

This PR changes the sortKey to the `sortBy` field if it is provided. It can be any string, default will be set to `id`.

Should be able to sort by a JSON nested field according to this ticket: https://stackoverflow.com/questions/47213802/sequelize-query-with-order-by-a-field-in-jsonb-object
Example here: https://github.com/sequelize/sequelize/blob/master/test/integration/model/json.test.js#L588

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/880
Blocked by https://github.com/screwdriver-cd/data-schema/pull/274