### PR TITLE
feat(880): Add search capability for scan [2]

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,6 +308,9 @@ class Squeakquel extends Datastore {
      * @param  {Number}   [config.paginate.count]   Number of items per page
      * @param  {Number}   [config.paginate.page]    Specific page of the set to return
      * @param  {Object}   [config.params]           index => values to query on
+     * @param  {Object}   [config.search]           Search parameters
+     * @param  {String}   [config.search.field]     Search field (eg: jobName)
+     * @param  {String}   [config.search.term]      Search term (eg: main)
      * @param  {String}   [config.sort]             Sorting option based on GSI range key. Ascending or descending.
      * @param  {String}   [config.sortBy]           Key to sort by; defaults to 'id'
      * @return {Promise}                            Resolves to an array of records
@@ -338,9 +341,13 @@ class Squeakquel extends Datastore {
                         [Sequelize.Op.in]: paramValue
                     };
                 } else if (paramName === 'search' && typeof paramValue === 'object') {
-                    findParams.where[paramValue.searchField] = {
-                        [Sequelize.Op.like]: paramValue.searchTerm
-                    };
+                    const validSearchFields = Object.keys(model.base.describe().children);
+
+                    if (validSearchFields.includes(paramValue.field)) {
+                        findParams.where[paramValue.field] = {
+                            [Sequelize.Op.like]: paramValue.term
+                        };
+                    }
                 } else {
                     findParams.where[paramName] = paramValue;
                 }

--- a/index.js
+++ b/index.js
@@ -343,11 +343,12 @@ class Squeakquel extends Datastore {
                         [Sequelize.Op.in]: paramValue
                     };
                 } else if (paramName === 'search' && typeof paramValue === 'object') {
-                    if (validFields.includes(paramValue.field)) {
-                        findParams.where[paramValue.field] = {
-                            [Sequelize.Op.like]: paramValue.keyword
-                        };
+                    if (!validFields.includes(paramValue.field)) {
+                        throw new Error(`Invalid search field "${paramValue.field}"`);
                     }
+                    findParams.where[paramValue.field] = {
+                        [Sequelize.Op.like]: paramValue.keyword
+                    };
                 } else {
                     findParams.where[paramName] = paramValue;
                 }
@@ -361,7 +362,10 @@ class Squeakquel extends Datastore {
             });
         }
 
-        if (config.sortBy && validFields.includes(config.sortBy)) {
+        if (config.sortBy) {
+            if (!validFields.includes(config.sortBy)) {
+                return Promise.reject(new Error(`Invalid sortBy "${config.sortBy}"`));
+            }
             sortKey = config.sortBy;
         }
 

--- a/index.js
+++ b/index.js
@@ -335,7 +335,11 @@ class Squeakquel extends Datastore {
 
                 if (Array.isArray(paramValue)) {
                     findParams.where[paramName] = {
-                        in: paramValue
+                        [Sequelize.Op.in]: paramValue
+                    };
+                } else if (paramName === 'search' && typeof paramValue === 'object') {
+                    findParams.where[paramValue.searchField] = {
+                        [Sequelize.Op.like]: paramValue.searchTerm
                     };
                 } else {
                     findParams.where[paramName] = paramValue;

--- a/index.js
+++ b/index.js
@@ -310,7 +310,7 @@ class Squeakquel extends Datastore {
      * @param  {Object}   [config.params]           index => values to query on
      * @param  {Object}   [config.search]           Search parameters
      * @param  {String}   [config.search.field]     Search field (eg: jobName)
-     * @param  {String}   [config.search.term]      Search term (eg: main)
+     * @param  {String}   [config.search.keyword]   Search keyword (eg: main)
      * @param  {String}   [config.sort]             Sorting option based on GSI range key. Ascending or descending.
      * @param  {String}   [config.sortBy]           Key to sort by; defaults to 'id'
      * @return {Promise}                            Resolves to an array of records
@@ -345,7 +345,7 @@ class Squeakquel extends Datastore {
                 } else if (paramName === 'search' && typeof paramValue === 'object') {
                     if (validFields.includes(paramValue.field)) {
                         findParams.where[paramValue.field] = {
-                            [Sequelize.Op.like]: paramValue.term
+                            [Sequelize.Op.like]: paramValue.keyword
                         };
                     }
                 } else {

--- a/index.js
+++ b/index.js
@@ -327,6 +327,8 @@ class Squeakquel extends Datastore {
             return Promise.reject(new Error(`Invalid table name "${config.table}"`));
         }
 
+        const validFields = Object.keys(model.base.describe().children);
+
         if (config.paginate) {
             findParams.limit = config.paginate.count;
             findParams.offset = findParams.limit * (config.paginate.page - 1);
@@ -341,9 +343,7 @@ class Squeakquel extends Datastore {
                         [Sequelize.Op.in]: paramValue
                     };
                 } else if (paramName === 'search' && typeof paramValue === 'object') {
-                    const validSearchFields = Object.keys(model.base.describe().children);
-
-                    if (validSearchFields.includes(paramValue.field)) {
+                    if (validFields.includes(paramValue.field)) {
                         findParams.where[paramValue.field] = {
                             [Sequelize.Op.like]: paramValue.term
                         };
@@ -361,7 +361,7 @@ class Squeakquel extends Datastore {
             });
         }
 
-        if (config.sortBy) {
+        if (config.sortBy && validFields.includes(config.sortBy)) {
             sortKey = config.sortBy;
         }
 

--- a/package.json
+++ b/package.json
@@ -39,20 +39,20 @@
   },
   "devDependencies": {
     "chai": "^4.0.2",
-    "eslint": "^4.16.0",
-    "eslint-config-screwdriver": "^3.0.0",
+    "eslint": "^4.19.1",
+    "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^4.1.2",
-    "joi": "^13.0.0",
+    "joi": "^13.6.0",
     "mockery": "^2.0.0",
     "sinon": "^2.3.2"
   },
   "dependencies": {
-    "mysql2": "^1.4.2",
+    "mysql2": "^1.6.1",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
-    "screwdriver-data-schema": "^18.0.0",
-    "screwdriver-datastore-base": "^3.0.1",
-    "sequelize": "^4.0.0",
-    "sqlite3": "^4.0.0"
+    "screwdriver-data-schema": "^18.32.3",
+    "screwdriver-datastore-base": "^3.0.7",
+    "sequelize": "^4.38.0",
+    "sqlite3": "^4.0.2"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -674,29 +674,7 @@ describe('index test', function () {
             });
         });
 
-        it('scans all the data and skips search if field does not exist in schema', () => {
-            const testData = [
-                {
-                    id: 'data2',
-                    scmRepo: '{"name": "Alpha"}',
-                    key: 'value2'
-                },
-                {
-                    id: 'data1',
-                    scmRepo: '{"name": "Beta"}',
-                    key: 'value1'
-                }
-            ];
-            const testInternal = [
-                {
-                    toJSON: sinon.stub().returns(testData[0])
-                },
-                {
-                    toJSON: sinon.stub().returns(testData[1])
-                }
-            ];
-
-            sequelizeTableMock.findAll.resolves(testInternal);
+        it('throws error if search field does not exist in schema', () => {
             testParams.params = {
                 search: {
                     field: 'banana',
@@ -704,12 +682,22 @@ describe('index test', function () {
                 }
             };
 
-            return datastore.scan(testParams).then((data) => {
-                assert.deepEqual(data, testData);
-                assert.calledWith(sequelizeTableMock.findAll, {
-                    where: { },
-                    order: [['id', 'DESC']]
-                });
+            return datastore.scan(testParams).then(() => {
+                throw new Error('Oops');
+            }).catch((err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.match(err.message, /Invalid search field "banana"/);
+            });
+        });
+
+        it('throws error if sortBy does not exist in schema', () => {
+            testParams.sortBy = 'banana';
+
+            return datastore.scan(testParams).then(() => {
+                throw new Error('Oops');
+            }).catch((err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.match(err.message, /Invalid sortBy "banana"/);
             });
         });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -635,7 +635,7 @@ describe('index test', function () {
             });
         });
 
-        it('scans all the data and returns based on search terms', () => {
+        it('scans all the data and returns based on search values', () => {
             const testData = [
                 {
                     id: 'data2',
@@ -661,7 +661,7 @@ describe('index test', function () {
             testParams.params = {
                 search: {
                     field: 'scmRepo',
-                    term: '%name%A%'
+                    keyword: '%name%A%'
                 }
             };
 
@@ -674,7 +674,7 @@ describe('index test', function () {
             });
         });
 
-        it('scans all the data and skips search if terms do not exist in schema', () => {
+        it('scans all the data and skips search if field does not exist in schema', () => {
             const testData = [
                 {
                     id: 'data2',
@@ -700,7 +700,7 @@ describe('index test', function () {
             testParams.params = {
                 search: {
                     field: 'banana',
-                    term: '%name%A%'
+                    keyword: '%name%A%'
                 }
             };
 


### PR DESCRIPTION
## Context
Since we're adding pagination for pipelines, we can no longer have search functionality stored in the UI. 

## Objective
This PR adds search capability for the datastore.

To do a search, it expects a param like this:
```
params: {
  search: {
    field: "scmRepo",
    term: "%name%Screwdriver%"
  }
}
```
It will first validate that the field `scmRepo` exists in the pipelines table then search for the term `Screwdriver` in the `scmRepo` field.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/880
Blocked by https://github.com/screwdriver-cd/data-schema/pull/278