### PR TITLE
fix(880): Move search outside of params

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,13 +342,6 @@ class Squeakquel extends Datastore {
                     findParams.where[paramName] = {
                         [Sequelize.Op.in]: paramValue
                     };
-                } else if (paramName === 'search' && typeof paramValue === 'object') {
-                    if (!validFields.includes(paramValue.field)) {
-                        throw new Error(`Invalid search field "${paramValue.field}"`);
-                    }
-                    findParams.where[paramValue.field] = {
-                        [Sequelize.Op.like]: paramValue.keyword
-                    };
                 } else {
                     findParams.where[paramName] = paramValue;
                 }
@@ -360,6 +353,15 @@ class Squeakquel extends Datastore {
                     sortKey = model.rangeKeys[indexIndex];
                 }
             });
+        }
+
+        if (config.search && config.search.field && config.search.keyword) {
+            if (!validFields.includes(config.search.field)) {
+                return Promise.reject(new Error(`Invalid search field "${config.search.field}"`));
+            }
+            findParams.where[config.search.field] = {
+                [Sequelize.Op.like]: config.search.keyword
+            };
         }
 
         if (config.sortBy) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -658,11 +658,9 @@ describe('index test', function () {
             ];
 
             sequelizeTableMock.findAll.resolves(testInternal);
-            testParams.params = {
-                search: {
-                    field: 'scmRepo',
-                    keyword: '%name%A%'
-                }
+            testParams.search = {
+                field: 'scmRepo',
+                keyword: '%name%A%'
             };
 
             return datastore.scan(testParams).then((data) => {
@@ -675,11 +673,9 @@ describe('index test', function () {
         });
 
         it('throws error if search field does not exist in schema', () => {
-            testParams.params = {
-                search: {
-                    field: 'banana',
-                    keyword: '%name%A%'
-                }
+            testParams.search = {
+                field: 'banana',
+                keyword: '%name%A%'
             };
 
             return datastore.scan(testParams).then(() => {


### PR DESCRIPTION
Should be `config.search`, not `config.params.search`

Related to https://github.com/screwdriver-cd/screwdriver/issues/880