### PR TITLE
feat(1271): Add support for distinct column search and multiple field search [2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     }
   },
   "devDependencies": {
-    "chai": "^4.0.2",
+    "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^4.1.2",
-    "joi": "^13.6.0",
+    "joi": "^13.7.0",
     "mockery": "^2.0.0",
     "sinon": "^2.3.2"
   },
@@ -50,9 +50,9 @@
     "mysql2": "^1.6.1",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
-    "screwdriver-data-schema": "^18.32.3",
+    "screwdriver-data-schema": "^18.32.7",
     "screwdriver-datastore-base": "^3.0.7",
-    "sequelize": "^4.38.0",
+    "sequelize": "^4.39.0",
     "sqlite3": "^4.0.2"
   }
 }


### PR DESCRIPTION
## Context
There are many improvements to be made on the templates/commands pages. It would be nice if we had built-in search capabilities. 
The redesign would allow users to choose a `namespace` from a dropdown of all template `namespaces`. This requires a new endpoint and datastore support (distinct column search).
The redesign also would allow users to search by keyword such as `nodejs` through all template `name`, `namespace`, and `description` fields. This requires datastore support (multiple field search).

## Objective
This PR adds support for distinct column search and multiple field search.

#### Distinct column search
Given a config like:
```
{
  params: {
    distinct: 'namespace'
  }
}
```
Returns all distinct `namespace` rows. [Sequelize documentation.](https://stackoverflow.com/a/45010576)

#### Multiple field search
Given a config like:
```
{
  search: {
    field: ['namespace', 'name', 'description'],
    keyword: '%nodejs%'
  }
}
```
Returns all results with "nodejs" in the `namespace`, `name`, or `description`. [Sequelize ref.](http://docs.sequelizejs.com/manual/tutorial/querying.html)

- Also added checks if the fields are valid and throws an error when it isn't

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1271
Blocked by https://github.com/screwdriver-cd/data-schema/pull/285