### PR TITLE
feat(1412): add compare timerange

### DIFF
--- a/index.js
+++ b/index.js
@@ -328,6 +328,8 @@ class Squeakquel extends Datastore {
      * @param  {String}         [config.search.keyword]   Search keyword (eg: main)
      * @param  {String}         [config.sort]             Sorting option based on GSI range key. Ascending or descending.
      * @param  {String}         [config.sortBy]           Key to sort by; defaults to 'id'
+     * @param  {String}         [config.startTime]        Search for records >= startTime
+     * @param  {String}         [config.endTime]          Search for records <= endTime
      * @return {Promise}                                  Resolves to an array of records
      */
     _scan(config) {
@@ -405,6 +407,16 @@ class Squeakquel extends Datastore {
                     [Sequelize.Op.like]: config.search.keyword
                 };
             }
+        }
+
+        // if query has startTime and endTime (for metrics)
+        if (config.startTime) {
+            findParams.where.createTime = { [Sequelize.Op.gte]: config.startTime };
+        }
+
+        if (config.endTime) {
+            findParams.where.createTime = findParams.where.createTime || {}; // in case there is no startTime
+            Object.assign(findParams.where.createTime, { [Sequelize.Op.lte]: config.endTime });
         }
 
         if (config.sortBy) {

--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
     "eslint-config-screwdriver": "^3.0.1",
     "jenkins-mocha": "^6.0.0",
     "joi": "^13.7.0",
-    "mockery": "^2.0.0",
+    "mockery": "^2.1.0",
     "sinon": "^2.3.2"
   },
   "dependencies": {
     "mysql2": "^1.6.1",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
-    "screwdriver-data-schema": "^18.35.1",
+    "screwdriver-data-schema": "^18.42.0",
     "screwdriver-datastore-base": "^3.0.7",
     "sequelize": "^4.39.0",
     "sqlite3": "^4.0.2"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,7 +92,9 @@ describe('index test', function () {
         sequelizeMock.Op = {
             in: 'IN',
             like: 'LIKE',
-            or: 'OR'
+            or: 'OR',
+            gte: 'GTE',
+            lte: 'LTE'
         };
         sequelizeMock.col = sinon.stub().returns('col');
         sequelizeMock.fn = sinon.stub().returnsArg(0);
@@ -959,7 +961,7 @@ describe('index test', function () {
             });
         });
 
-        it('scan and return grouped data with excluded field(s)', () => {
+        it('scans and returns grouped data with excluded field(s)', () => {
             const testData = [
                 {
                     id: 'data1',
@@ -1025,6 +1027,24 @@ describe('index test', function () {
             }).catch((err) => {
                 assert.isOk(err, 'Error should be returned');
                 assert.match(err.message, testError.message);
+            });
+        });
+
+        it('scans for data within date range', () => {
+            sequelizeTableMock.findAll.resolves([]);
+            testParams.startTime = '2019-01-28T11:00:00.000Z';
+            testParams.endTime = '2019-01-28T12:00:00.000Z';
+
+            return datastore.scan(testParams).then(() => {
+                assert.calledWith(sequelizeTableMock.findAll, {
+                    where: {
+                        createTime: {
+                            GTE: testParams.startTime,
+                            LTE: testParams.endTime
+                        }
+                    },
+                    order: [['id', 'DESC']]
+                });
             });
         });
     });


### PR DESCRIPTION
Allows scanning for time range. `startTime` and `endTime` will be passed in by models (https://github.com/screwdriver-cd/models/pull/319) when trying to look for records within a time range. 

Related:
https://github.com/screwdriver-cd/screwdriver/issues/1412