### PR TITLE
fix: Output alter and slow query logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ class Squeakquel extends Datastore {
             if (log.includes('ALTER')) {
                 this.logger.info(`Executed alter query: ${log}`);
             } else if (time >= this.slowlogThreshold) {
-                this.logger.warn(`Slowlog detected: ${log}`);
+                this.logger.warn(`Slow log detected: ${log}`);
             }
         };
         this.prefix = config.prefix || '';

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "screwdriver-data-schema": "^18.42.0",
     "screwdriver-datastore-base": "^3.0.7",
     "sequelize": "^4.39.0",
-    "sqlite3": "^4.0.2"
+    "sqlite3": "^4.0.2",
+    "winston": "^3.2.1"
   }
 }


### PR DESCRIPTION
I added log function so that users can determine which query is slow and see what alter query are issued.

Query execution time will be passed to the second argument of logger function if `benchmark` option is enabled.
The first argument is just a message including a query.
https://github.com/sequelize/sequelize/blob/8df9b8f3c8ff15427d8adbeb2c712dfe7df694d4/lib/dialects/mysql/query.js#L63

Reference:
http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor