### PR TITLE
fix: remove index creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,8 +182,7 @@ class Squeakquel extends Datastore {
         const fields = schema.base.describe().children;
         const tableFields = {};
         const tableOptions = {
-            timestamps: false,
-            indexes: schema.indexes
+            timestamps: false
         };
 
         Object.keys(fields).forEach((fieldName) => {


### PR DESCRIPTION
sd api pods crashing due to index rebuilding. will separate out index creation process. disabling index creation via sequelize