### PR TITLE
fix: revert - remove index creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -182,7 +182,8 @@ class Squeakquel extends Datastore {
         const fields = schema.base.describe().children;
         const tableFields = {};
         const tableOptions = {
-            timestamps: false
+            timestamps: false,
+            indexes: schema.indexes
         };
 
         Object.keys(fields).forEach((fieldName) => {


### PR DESCRIPTION
Reverts screwdriver-cd/datastore-sequelize#43. DB issue was because of column alterations and not becoz of the index. Reverting the changes. Ideally need to move db related changes to a new pipeline.