### PR TITLE
fix: allow time based filtering using a different key

### DIFF
--- a/index.js
+++ b/index.js
@@ -428,7 +428,7 @@ class Squeakquel extends Datastore {
         }
 
         // if query has startTime and endTime (for metrics)
-        const timeKey = config.timeKey ? config.timeKey : 'createTime';
+        const timeKey = config.timeKey || 'createTime';
 
         if (config.startTime) {
             findParams.where[timeKey] = { [Sequelize.Op.gte]: config.startTime };

--- a/index.js
+++ b/index.js
@@ -428,13 +428,15 @@ class Squeakquel extends Datastore {
         }
 
         // if query has startTime and endTime (for metrics)
+        const timeKey = config.timeKey ? config.timeKey : 'createTime';
+
         if (config.startTime) {
-            findParams.where.createTime = { [Sequelize.Op.gte]: config.startTime };
+            findParams.where[timeKey] = { [Sequelize.Op.gte]: config.startTime };
         }
 
         if (config.endTime) {
-            findParams.where.createTime = findParams.where.createTime || {}; // in case there is no startTime
-            Object.assign(findParams.where.createTime, { [Sequelize.Op.lte]: config.endTime });
+            findParams.where[timeKey] = findParams.where[timeKey] || {}; // in case there is no startTime
+            Object.assign(findParams.where[timeKey], { [Sequelize.Op.lte]: config.endTime });
         }
 
         if (config.sortBy) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mysql2": "^1.6.1",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
-    "screwdriver-data-schema": "^18.42.0",
+    "screwdriver-data-schema": "^18.43.2",
     "screwdriver-datastore-base": "^3.0.7",
     "sequelize": "^4.39.0",
     "sqlite3": "^4.0.2",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1047,5 +1047,24 @@ describe('index test', function () {
                 });
             });
         });
+
+        it('scans for data within date range using time key', () => {
+            sequelizeTableMock.findAll.resolves([]);
+            testParams.startTime = '2019-01-28T11:00:00.000Z';
+            testParams.endTime = '2019-01-28T12:00:00.000Z';
+            testParams.timeKey = 'startTime';
+
+            return datastore.scan(testParams).then(() => {
+                assert.calledWith(sequelizeTableMock.findAll, {
+                    where: {
+                        startTime: {
+                            GTE: testParams.startTime,
+                            LTE: testParams.endTime
+                        }
+                    },
+                    order: [['id', 'DESC']]
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
For events & pipelines, we can use `createTime` to filter time range
For steps, there is no `createTime`. For filtering, we should use `startTime` field instead. This PR allows flexibility to filter time using a different key. 
I call this field `timeKey`, but I'm open to suggestion on what's a good name for this field. 

Related: 
https://github.com/screwdriver-cd/screwdriver/issues/1412