### PR TITLE
fix: iLike with uppercase L

### DIFF
--- a/index.js
+++ b/index.js
@@ -402,7 +402,7 @@ class Squeakquel extends Datastore {
 
         if (config.search && config.search.field && config.search.keyword) {
             const searchKey = this.client.getDialect() === 'postgres'
-                ? { [Sequelize.Op.ilike]: config.search.keyword }
+                ? { [Sequelize.Op.iLike]: config.search.keyword }
                 : { [Sequelize.Op.like]: config.search.keyword };
 
             // If field is array, search for keyword in all fields

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,7 +92,7 @@ describe('index test', function () {
         sequelizeMock.Op = {
             in: 'IN',
             like: 'LIKE',
-            ilike: 'ILIKE',
+            iLike: 'ILIKE',
             or: 'OR',
             gte: 'GTE',
             lte: 'LTE'


### PR DESCRIPTION
Should be `iLike`, not `ilike`. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1272