### PR TITLE
fix: update sequelize to 5.3.x to fix security vulnerability

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,7 +242,7 @@ class Squeakquel extends Datastore {
                 where: config.params
             });
         } else {
-            finder = table.findById(config.params.id);
+            finder = table.findByPk(config.params.id);
         }
 
         return finder.then(item => decodeFromDialect(this.client.getDialect(), item, model));

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pg-hstore": "^2.3.2",
     "screwdriver-data-schema": "^18.45.0",
     "screwdriver-datastore-base": "^3.0.7",
-    "sequelize": "^4.43.0",
+    "sequelize": "^5.3.0",
     "sqlite3": "^4.0.2",
     "winston": "^3.2.1"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,7 +66,7 @@ describe('index test', function () {
             create: sinon.stub(),
             destroy: sinon.stub(),
             findAll: sinon.stub(),
-            findById: sinon.stub(),
+            findByPk: sinon.stub(),
             findOne: sinon.stub(),
             update: sinon.stub()
         };
@@ -234,12 +234,12 @@ describe('index test', function () {
                 }
             };
 
-            sequelizeTableMock.findById.resolves(responseMock);
+            sequelizeTableMock.findByPk.resolves(responseMock);
             responseMock.toJSON.returns(testData);
 
             return datastore.get(testParams).then((data) => {
                 assert.deepEqual(data, realData);
-                assert.calledWith(sequelizeTableMock.findById, testParams.params.id);
+                assert.calledWith(sequelizeTableMock.findByPk, testParams.params.id);
             });
         });
 
@@ -279,7 +279,7 @@ describe('index test', function () {
         });
 
         it('gracefully understands that no one is returned when it does not exist', () => {
-            sequelizeTableMock.findById.resolves(null);
+            sequelizeTableMock.findByPk.resolves(null);
 
             return datastore.get({
                 table: 'pipelines',
@@ -306,7 +306,7 @@ describe('index test', function () {
         it('fails when it encounters an error', () => {
             const testError = new Error('errorCommunicatingToApi');
 
-            sequelizeTableMock.findById.rejects(testError);
+            sequelizeTableMock.findByPk.rejects(testError);
 
             return datastore._get({
                 table: 'pipelines',


### PR DESCRIPTION
- update sequelize to 5.3.x to fix security vulnerability
- I have checked the breaking changes in the release doc for v5 and fixed it in our code accordingly: https://github.com/sequelize/sequelize/releases/tag/v5.1.0

PR opened by Snyk: https://github.com/screwdriver-cd/datastore-sequelize/pull/50
