### PR TITLE
feat(1664): make sequalize ddl sync optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,12 +222,15 @@ class Squeakquel extends Datastore {
     }
 
     /**
-     * Get tables in order
+     * Database schema will be synced based on syncViaAPI environment variable
      * @method setup
      * @return {Promise}
      */
-    setup() {
-        return this.client.sync({ alter: true });
+    setup(ddlSyncEnabled) {
+        this.logger.info(`Datastore ddl sync enabled: ${ddlSyncEnabled}`);
+        if (ddlSyncEnabled === 'true') { return this.client.sync({ alter: true }); }
+
+        return Promise.resolve();
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -228,7 +228,9 @@ class Squeakquel extends Datastore {
      */
     setup(ddlSyncEnabled) {
         this.logger.info(`Datastore ddl sync enabled: ${ddlSyncEnabled}`);
-        if (ddlSyncEnabled === 'true') { return this.client.sync({ alter: true }); }
+        if (ddlSyncEnabled === 'true') {
+            return this.client.sync({ alter: true });
+        }
 
         return Promise.resolve();
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -202,10 +202,24 @@ describe('index test', function () {
 
     describe('sync', () => {
         it('syncs tables', () => {
+            const ddlSyncEnabled = 'true';
+
             sequelizeClientMock.sync.resolves('moo');
 
-            return datastore.setup().then((data) => {
+            return datastore.setup(ddlSyncEnabled).then((data) => {
                 assert.deepEqual(data, 'moo');
+            });
+        });
+
+        it('doesnt sync tables', () => {
+            const ddlSyncEnabled = 'false';
+
+            sequelizeClientMock.sync.resolves(Promise.resolve());
+
+            return datastore.setup(ddlSyncEnabled).then(() => {
+                // do nothing
+            }).catch(() => {
+                assert.fail('this should not get here');
             });
         });
     });


### PR DESCRIPTION
## Context

Screwdriver database DDL changes are applied during Screwdriver api startup, which leads to api experiencing slowness or goes to the unreachable state. This does table-level exclusive locks because of 1. DDL statements are executed in parallel from multiple pods and 2. ALTER statements are executed even though no changes made to the database schema. Root-cause for this issue is calling Sequelize sync method with { alter: true } parameter.

## Objective

This PR addresses sequelize ddl sync required or optional based on an environment variable setting.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1664

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
