### PR TITLE
fix: move sqlite3 to postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
+    "postinstall": "npm install sqlite3@4.1.0 --build-from-source",
     "test": "jenkins-mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -8,7 +8,6 @@ jobs:
         requires: [~pr, ~commit]
         steps:
             - install: npm install
-            - postinstall: npm install sqlite3@4.1.0 --build-from-source
             - test: npm test
 
     publish:


### PR DESCRIPTION
move to postinstall script

Related: https://github.com/screwdriver-cd/datastore-sequelize/pull/56