### PR TITLE
fix(1763): extends the data size of object from `TEXT` to `MEDIUMTEXT`

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,9 @@ function getSequelizeTypeFromJoi(dialect, type, rules) {
 
         return Sequelize.TEXT;
     case 'array':
-    case 'object':
         return Sequelize.TEXT;
+    case 'object':
+        return Sequelize.TEXT('medium');
     case 'date':
         return Sequelize.DATE;
     case 'number':

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,10 +1,12 @@
 'use strict';
 
+/* eslint new-cap: ["error", { "capIsNewExceptionPattern": "^Sequelize\.." }] */
 /* eslint-disable no-underscore-dangle */
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
 const joi = require('joi');
+const Sequelize = require('sequelize');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -79,16 +81,15 @@ describe('index test', function () {
             get: sinon.stub()
         };
         sequelizeMock = sinon.stub().returns(sequelizeClientMock);
-        sequelizeMock.STRING = sinon.stub().withArgs(40).returns('VARCHAR(40)');
-        sequelizeMock.TEXT = 'TEXT';
-        sequelizeMock.DATE = 'DATE';
-        sequelizeMock.DOUBLE = 'DOUBLE';
-        sequelizeMock.INTEGER = {};
-        sequelizeMock.INTEGER.UNSIGNED = 'UNSIGNED INTEGER';
-        sequelizeMock.BOOLEAN = 'BOOLEAN';
-        sequelizeMock.BLOB = 'BLOB';
-        sequelizeMock.JSON = 'JSON';
-        sequelizeMock.ARRAY = sinon.stub().returns('ARRAY');
+        sequelizeMock.STRING = Sequelize.STRING;
+        sequelizeMock.TEXT = Sequelize.TEXT;
+        sequelizeMock.DATE = Sequelize.DATE;
+        sequelizeMock.DOUBLE = Sequelize.DOUBLE;
+        sequelizeMock.INTEGER = Sequelize.INTEGER;
+        sequelizeMock.BOOLEAN = Sequelize.BOOLEAN;
+        sequelizeMock.BLOB = Sequelize.BLOB;
+        sequelizeMock.JSON = Sequelize.JSON;
+        sequelizeMock.ARRAY = Sequelize.ARRAY;
         sequelizeMock.Op = {
             in: 'IN',
             like: 'LIKE',
@@ -139,52 +140,52 @@ describe('index test', function () {
             });
             assert.calledWith(sequelizeClientMock.define, 'jobs', {
                 id: {
-                    type: 'UNSIGNED INTEGER',
+                    type: Sequelize.INTEGER.UNSIGNED,
                     primaryKey: true,
                     autoIncrement: true
                 },
                 name: {
-                    type: 'TEXT',
+                    type: Sequelize.TEXT,
                     unique: 'uniquerow'
                 }
             });
             assert.calledWith(sequelizeClientMock.define, 'pipelines', {
                 id: {
-                    type: 'UNSIGNED INTEGER',
+                    type: Sequelize.INTEGER.UNSIGNED,
                     primaryKey: true,
                     autoIncrement: true
                 },
                 str: {
-                    type: 'TEXT',
+                    type: Sequelize.TEXT,
                     unique: 'uniquerow'
                 },
                 date: {
-                    type: 'DATE'
+                    type: Sequelize.DATE
                 },
                 num: {
-                    type: 'DOUBLE',
+                    type: Sequelize.DOUBLE,
                     unique: 'uniquerow'
                 },
                 bool: {
-                    type: 'BOOLEAN'
+                    type: Sequelize.BOOLEAN
                 },
                 bin: {
-                    type: 'BLOB'
+                    type: Sequelize.BLOB
                 },
                 arr: {
-                    type: 'TEXT'
+                    type: Sequelize.TEXT
                 },
                 obj: {
-                    type: 'TEXT'
+                    type: Sequelize.TEXT('medium')
                 },
                 any: {
                     type: null
                 },
                 namespace: {
-                    type: 'TEXT'
+                    type: Sequelize.TEXT
                 },
                 name: {
-                    type: 'TEXT'
+                    type: Sequelize.TEXT
                 }
             });
         });


### PR DESCRIPTION
## Context
`meta` object is defined as `TEXT` type in MySQL.
The data size of `TEXT` type in MySQL is limited in 64KB, but the `meta` data tend to be bigger because it includes various items (e.g. `commit.changedFiles` may have many files and each file may be very long file name). And the meta has being empty object if the size is over. We have had such situation.

## Objective
This extends the data size of columns defined as `object` in data-schema from `TEXT`(64KB in MySQL) to `MEDIUMTEXT`(16MB in MySQL) if the Database supports `MEDIUMTEXT`.

## TODO
- [x] Needs migration script for this change?
  - => https://github.com/screwdriver-cd/data-schema/pull/356

## References
https://github.com/screwdriver-cd/screwdriver/issues/1763
https://sequelize.org/master/class/lib/data-types.js~TEXT.html

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
