### PR TITLE
fix(1723): Change the query to the last updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -482,6 +482,8 @@ class Squeakquel extends Datastore {
             config.groupBy.forEach((v) => {
                 where[v] = { [Sequelize.Op.eq]: Sequelize.col(`${config.table}.${v}`) };
             });
+
+            // Slice method deletes `;`
             const subQuery = this.client.dialect.QueryGenerator.selectQuery(config.table, {
                 tableAs: 't',
                 attributes: [Sequelize.fn('MAX', Sequelize.col('t.id'))],

--- a/index.js
+++ b/index.js
@@ -472,10 +472,23 @@ class Squeakquel extends Datastore {
                     col = Sequelize.cast(col, 'integer');
                 }
 
-                return [Sequelize.fn('MAX', col), field];
+                return [col, field];
             });
-            findParams.group = [...config.groupBy];
-            sortKey = Sequelize.fn('MAX', Sequelize.col(sortKey));
+
+            sortKey = Sequelize.col(sortKey);
+
+            const where = { id: { [Sequelize.Op.gte]: Sequelize.col(`${config.table}.id`) } };
+
+            config.groupBy.forEach((v) => {
+                where[v] = { [Sequelize.Op.eq]: Sequelize.col(`${config.table}.${v}`) };
+            });
+            const subQuery = this.client.dialect.QueryGenerator.selectQuery(config.table, {
+                tableAs: 't',
+                attributes: [Sequelize.fn('MAX', Sequelize.col('t.id'))],
+                where
+            }).slice(0, -1);
+
+            findParams.where = { id: { [Sequelize.Op.eq]: this.client.literal(`(${subQuery})`) } };
         }
 
         if (config.sort === 'ascending') {

--- a/index.js
+++ b/index.js
@@ -483,7 +483,7 @@ class Squeakquel extends Datastore {
                 where[v] = { [Sequelize.Op.eq]: Sequelize.col(`${config.table}.${v}`) };
             });
 
-            // Slice method deletes `;`
+            // slice() method deletes `;`
             const subQuery = this.client.dialect.QueryGenerator.selectQuery(config.table, {
                 tableAs: 't',
                 attributes: [Sequelize.fn('MAX', Sequelize.col('t.id'))],

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,6 +54,8 @@ describe('index test', function () {
     let Datastore;
     let sequelizeRowMock;
     let sequelizeTableMock;
+    let sequelizeQueryGeneratorMock;
+    let sequelizeDialectMock;
     let sequelizeClientMock;
     let sequelizeMock;
     let responseMock;
@@ -70,10 +72,18 @@ describe('index test', function () {
             findOne: sinon.stub(),
             update: sinon.stub()
         };
+        sequelizeQueryGeneratorMock = {
+            selectQuery: sinon.stub()
+        };
+        sequelizeDialectMock = {
+            QueryGenerator: sequelizeQueryGeneratorMock
+        };
         sequelizeClientMock = {
             define: sinon.stub().returns(sequelizeTableMock),
             sync: sinon.stub().resolves(),
-            getDialect: sinon.stub().returns('sqlite')
+            getDialect: sinon.stub().returns('sqlite'),
+            literal: sinon.stub(),
+            dialect: sequelizeDialectMock
         };
         sequelizeRowMock = {
             get: sinon.stub()
@@ -95,7 +105,8 @@ describe('index test', function () {
             iLike: 'ILIKE',
             or: 'OR',
             gte: 'GTE',
-            lte: 'LTE'
+            lte: 'LTE',
+            eq: 'EQ'
         };
         sequelizeMock.col = sinon.stub().returns('col');
         sequelizeMock.fn = sinon.stub().returnsArg(0);
@@ -1028,16 +1039,20 @@ describe('index test', function () {
             testParams.table = 'jobs';
             testParams.exclude = ['id'];
             testParams.groupBy = ['key'];
-
+            sequelizeQueryGeneratorMock.selectQuery.withArgs('jobs', {
+                tableAs: 't',
+                attributes: ['MAX'],
+                where: { id: { GTE: 'col' }, key: { EQ: 'col' } }
+            }).returns('subQuery;');
+            sequelizeClientMock.literal.withArgs('(subQuery)').returns('literal');
             sequelizeTableMock.findAll.resolves(testInternal);
 
             return datastore.scan(testParams).then((data) => {
                 assert.notDeepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
-                    attributes: [['MAX', 'name']],
-                    group: ['key'],
-                    where: {},
-                    order: [['MAX', 'DESC']]
+                    attributes: [['col', 'name']],
+                    where: { id: { EQ: 'literal' } },
+                    order: [['col', 'DESC']]
                 });
             });
         });


### PR DESCRIPTION
## Context
This pr is that discussed in this issue.
https://github.com/screwdriver-cd/screwdriver/issues/1723

Current templates and commands page shows  the template with `MAX`.
It should shows template and command that sorted by createTime. However, in order to get the version number of the latest template, there are cases where it is not possible to use `createTime`, so I adopted `id`. I fixed to use below SQL.
```
> SELECT id, name, namespace ...
FROM templates 
WHERE templates.id = (
  SELECT MAX(t.id) 
  FROM templates AS t 
  WHERE templates.name = t.name 
  AND templates.namespace = t.namespace 
  AND templates.id <= t.id
) 
ORDER BY createTime ... ;

+----+-------+-------------+---------+------------+
| id | name  | namespace   | version | createTime |
+----+-------+-------------+---------+------------+
|  2 | foo   | bar         | 0.0.1   | NULL       |
+----+-------+-------------+---------+------------+
``` 

I use subquery only when there is arguments of groupBy.
And I put groupBy arguments in subquery `WHERE`.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->



## References
https://github.com/screwdriver-cd/screwdriver/issues/1723
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
