### PR TITLE
fix: use LOG_LEVEL for winston

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,6 +140,7 @@ class Squeakquel extends Datastore {
 
         this.slowlogThreshold = config.slowlogThreshold || 1000;
         this.logger = winston.createLogger({
+            level: process.env.LOG_LEVEL || 'info',
             format: winston.format.simple()
         });
         this.logger.add(


### PR DESCRIPTION
## Context

log level is not setup properly.

## Objective

Use LOG_LEVEL env var for loggin

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
