### PR TITLE
fix: use proper prefix in subquery

### DIFF
--- a/index.js
+++ b/index.js
@@ -485,14 +485,15 @@ class Squeakquel extends Datastore {
 
             sortKey = Sequelize.col(sortKey);
 
-            const where = { id: { [Sequelize.Op.gte]: Sequelize.col(`${config.table}.id`) } };
+            const tableName = `${this.prefix}${config.table}`;
+            const where = { id: { [Sequelize.Op.gte]: Sequelize.col(`${tableName}.id`) } };
 
             config.groupBy.forEach((v) => {
-                where[v] = { [Sequelize.Op.eq]: Sequelize.col(`${config.table}.${v}`) };
+                where[v] = { [Sequelize.Op.eq]: Sequelize.col(`${tableName}.${v}`) };
             });
 
             // slice() method deletes `;`
-            const subQuery = this.client.dialect.QueryGenerator.selectQuery(config.table, {
+            const subQuery = this.client.dialect.QueryGenerator.selectQuery(tableName, {
                 tableAs: 't',
                 attributes: [Sequelize.fn('MAX', Sequelize.col('t.id'))],
                 where


### PR DESCRIPTION
## Context

Subquery call is not using prefix for referring table name. 

## Objective

Use proper table prefix when subquery is constructed. 

## References

https://github.com/screwdriver-cd/datastore-sequelize/pull/59/files#issuecomment-561554294

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
