### PR TITLE
fix(1857): Show trusted mark on templates/commands list screen

### DIFF
--- a/index.js
+++ b/index.js
@@ -479,8 +479,8 @@ class Squeakquel extends Datastore {
                 // This subQuery is used on fiels of SELECT clause.
                 // This needs to delete after the trusted table generated.
                 if (field === 'trusted') {
-
                     let subCol = Sequelize.col('trusted');
+
                     subCol = Sequelize.cast(subCol, 'integer');
 
                     const subQueryForTrusted = this.client.dialect

--- a/index.js
+++ b/index.js
@@ -360,6 +360,7 @@ class Squeakquel extends Datastore {
     _scan(config) {
         const table = this.tables[config.table];
         const model = this.models[config.table];
+        const tableName = `${this.prefix}${config.table}`;
         const findParams = {
             where: {}
         };
@@ -478,17 +479,16 @@ class Squeakquel extends Datastore {
                 // This subQuery is used on fiels of SELECT clause.
                 // This needs to delete after the trusted table generated.
                 if (field === 'trusted') {
-                    // TODO: config.table -> tableName
                     const subQueryForTrusted = this.client.dialect
-                        .QueryGenerator.selectQuery(config.table, {
+                        .QueryGenerator.selectQuery(tableName, {
                             tableAs: 't1',
                             attributes: [Sequelize.fn('MAX', Sequelize.col('trusted'))],
                             where: {
                                 name: {
-                                    [Sequelize.Op.eq]: Sequelize.col(`${config.table}.name`)
+                                    [Sequelize.Op.eq]: Sequelize.col(`${tableName}.name`)
                                 },
                                 namespace: {
-                                    [Sequelize.Op.eq]: Sequelize.col(`${config.table}.namespace`)
+                                    [Sequelize.Op.eq]: Sequelize.col(`${tableName}.namespace`)
                                 }
                             }
                         }).slice(0, -1);
@@ -506,7 +506,6 @@ class Squeakquel extends Datastore {
 
             sortKey = Sequelize.col(sortKey);
 
-            const tableName = `${this.prefix}${config.table}`;
             const where = { id: { [Sequelize.Op.gte]: Sequelize.col(`${tableName}.id`) } };
 
             config.groupBy.forEach((v) => {

--- a/index.js
+++ b/index.js
@@ -479,10 +479,14 @@ class Squeakquel extends Datastore {
                 // This subQuery is used on fiels of SELECT clause.
                 // This needs to delete after the trusted table generated.
                 if (field === 'trusted') {
+
+                    let subCol = Sequelize.col('trusted');
+                    subCol = Sequelize.cast(subCol, 'integer');
+
                     const subQueryForTrusted = this.client.dialect
                         .QueryGenerator.selectQuery(tableName, {
                             tableAs: 't1',
-                            attributes: [Sequelize.fn('MAX', Sequelize.col('trusted'))],
+                            attributes: [Sequelize.fn('MAX', subCol)],
                             where: {
                                 name: {
                                     [Sequelize.Op.eq]: Sequelize.col(`${tableName}.name`)


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

This PR fixes the issue below.  
https://github.com/screwdriver-cd/screwdriver/issues/1857

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
The trusted mark is disappeared by the PR below.  
https://github.com/screwdriver-cd/datastore-sequelize/pull/59

That is because the trusted value is assigned only first version of template.
This PR fixes the issue by refer the MAX value of trusted column.
The SQL is like below.
```sql
SELECT
  id,
  name,
  version,
  namespace,
  (
    -- Start the new subquery that this PR add.
    SELECT
      MAX(trusted)
    FROM
      templates
    WHERE
      t1.name = name
      AND t1.namespace = namespace
     -- End the new subquery
  ) AS trusted
FROM
  templates AS t1
WHERE
  t1.id IN (
    SELECT
      MAX(t2.id)
    FROM
      templates AS t2
    WHERE
      t1.name = t2.name
      AND t1.namespace = t2.namespace
      AND t1.id <= t2.id
  )
ORDER BY
  createTime;
```

This PR seems to be temporary because it does not give enough abstracted function to put on `datastore-sequelize`. In other word, that is too much designated for `templates` and `commands` table.

I do not add test because I can't find the way to test that's fits this situation. However, this code is temporary, or which will be deleted one of these days, so I decided not to make the test for such code.

The best idea is that trusted column is divided from templates or commands table in my thought.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1857  
https://github.com/screwdriver-cd/datastore-sequelize/pull/59


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
