### PR TITLE
fix(1710): fix type key null for Joi.alternatives()

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,6 +118,8 @@ function getSequelizeTypeFromJoi(dialect, type, rules) {
         return Sequelize.BOOLEAN;
     case 'binary':
         return Sequelize.BLOB;
+    case 'alternatives':
+        return Sequelize.TEXT('medium');
     default:
         return null;
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,6 +40,18 @@ describe('index test', function () {
                 keys: ['name'],
                 indexes: ['name'],
                 rangeKeys: ['name']
+            },
+            trigger: {
+                base: joi.object({
+                    id: joi.string().length(40),
+                    src: joi.alternatives().try(
+                        joi.string().max(100)),
+                    dest: joi.alternatives().try(
+                        joi.string().max(100))
+                }),
+                tableName: 'triggers',
+                keys: ['src', 'dest'],
+                indexes: ['dest', 'src']
             }
         },
         plugins: {
@@ -157,6 +169,21 @@ describe('index test', function () {
                 },
                 name: {
                     type: Sequelize.TEXT,
+                    unique: 'uniquerow'
+                }
+            });
+            assert.calledWith(sequelizeClientMock.define, 'triggers', {
+                id: {
+                    type: Sequelize.INTEGER.UNSIGNED,
+                    primaryKey: true,
+                    autoIncrement: true
+                },
+                src: {
+                    type: Sequelize.TEXT('medium'),
+                    unique: 'uniquerow'
+                },
+                dest: {
+                    type: Sequelize.TEXT('medium'),
                     unique: 'uniquerow'
                 }
             });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -45,9 +45,11 @@ describe('index test', function () {
                 base: joi.object({
                     id: joi.string().length(40),
                     src: joi.alternatives().try(
-                        joi.string().max(100)),
+                        joi.object().max(64),
+                        joi.string().max(64)),
                     dest: joi.alternatives().try(
-                        joi.string().max(100))
+                        joi.object().max(64),
+                        joi.string().max(64))
                 }),
                 tableName: 'triggers',
                 keys: ['src', 'dest'],


### PR DESCRIPTION
## Context

When Joi.alternatives() is used, Sequelize data type is returned as null, which leads to TypeError: Cannot read property 'key' of null

## Objective

Return Sequelize.TEXT('medium') data type for Joi.alternatives().

## References

[1710](https://github.com/screwdriver-cd/screwdriver/issues/1710)

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
