### PR TITLE
fix: Use Sequelize.STRING with length

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,6 +119,10 @@ function getSequelizeTypeFromJoi(dialect, type, rules) {
     case 'binary':
         return Sequelize.BLOB;
     case 'alternatives':
+        if (length) {
+            return Sequelize.STRING(length);
+        }
+
         return Sequelize.TEXT('medium');
     default:
         return null;
@@ -191,11 +195,21 @@ class Squeakquel extends Datastore {
 
         Object.keys(fields).forEach((fieldName) => {
             const field = fields[fieldName];
+
+            let rules;
+
+            if (field.alternatives) {
+                // For schema using alternatives like triggers table.
+                rules = field.alternatives[0].rules;
+            } else {
+                rules = field.rules;
+            }
+
             const output = {
                 type: getSequelizeTypeFromJoi(
                     this.client.getDialect(),
                     field.type,
-                    field.rules || []
+                    rules || []
                 )
             };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -181,11 +181,11 @@ describe('index test', function () {
                     autoIncrement: true
                 },
                 src: {
-                    type: Sequelize.TEXT('medium'),
+                    type: Sequelize.STRING(64),
                     unique: 'uniquerow'
                 },
                 dest: {
-                    type: Sequelize.TEXT('medium'),
+                    type: Sequelize.STRING(64),
                     unique: 'uniquerow'
                 }
             });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

I filed to apply screwdriver-api `v0.5.820` for this error.

```
{"message":"Datastore ddl sync enabled: true","level":"info","timestamp":"2020-01-06T03:58:44.586Z"}
{"name":"SequelizeDatabaseError","parent":{"code":"ER_BLOB_KEY_WITHOUT_LENGTH","errno":1170,"sqlState":"42000","sqlMessage":"BLOB/TEXT column 'src' used in key specification without a key length","sql":"CREATE TABLE IF NOT EXISTS `triggers` (`id` INTEGER UNSIGNED auto_increment , `src` MEDIUMTEXT, `dest` MEDIUMTEXT, UNIQUE `uniquerow` (`src`, `dest`), PRIMARY KEY (`id`)) ENGINE=InnoDB;"},"original":{"code":"ER_BLOB_KEY_WITHOUT_LENGTH","errno":1170,"sqlState":"42000","sqlMessage":"BLOB/TEXT column 'src' used in key specification without a key length","sql":"CREATE TABLE IF NOT EXISTS `triggers` (`id` INTEGER UNSIGNED auto_increment , `src` MEDIUMTEXT, `dest` MEDIUMTEXT, UNIQUE `uniquerow` (`src`, `dest`), PRIMARY KEY
(`id`)) ENGINE=InnoDB;"},"sql":"CREATE TABLE IF NOT EXISTS `triggers` (`id` INTEGER UNSIGNED auto_increment , `src` MEDIUMTEXT, `dest` MEDIUMTEXT, UNIQUE `uniquerow` (`src`, `dest`), PRIMARY KEY (`id`)) ENGINE=InnoDB;","level":"error","timestamp":"2020-01-06T03:58:44.951Z"}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! screwdriver-api@0.5.820 start: `./bin/server`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the screwdriver-api@0.5.820 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm WARN Local package.json exists, but node_modules missing, did you mean to install?
npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2020-01-06T03_58_44_965Z-debug.log
```

This is because `triggers` table using BLOB/TEXT type and Sequelize does not apply length for BLOB/TEXT in MySQL. This PR fixes it.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

The cluster using MySQL is able to start screwdriver-api.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
Almost same PR.
https://github.com/screwdriver-cd/datastore-sequelize/pull/10



## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
