### PR TITLE
fix: use node:12 container

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "preinstall": "npm install sqlite3@4.1.0 --build-from-source",
     "test": "jenkins-mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Screwdriver API is running on node:12 container which is no longer supported.

## Objective

Upgrade to latest LTS of node. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/1722

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
