### PR TITLE
feat(1091): add ability to do aggregation query

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,6 +371,7 @@ class Squeakquel extends Datastore {
      * @param  {String}         [config.sortBy]           Key to sort by; defaults to 'id'
      * @param  {String}         [config.startTime]        Search for records >= startTime
      * @param  {String}         [config.endTime]          Search for records <= endTime
+     * @param {String}          [config.aggregationField] Field that will be aggregated in aggregation query
      * @return {Promise}                                  Resolves to an array of records
      */
     _scan(config) {
@@ -546,6 +547,20 @@ class Squeakquel extends Datastore {
             findParams.order = [[sortKey, 'ASC']];
         } else {
             findParams.order = [[sortKey, 'DESC']];
+        }
+
+        if (config.aggregationField) {
+            if (!findParams.attributes) {
+                findParams.attributes = [];
+            }
+
+            findParams.attributes.push(config.aggregationField);
+            findParams.attributes.push([
+                Sequelize.fn('COUNT', Sequelize.col(config.aggregationField)),
+                'count']
+            );
+
+            findParams.group = config.aggregationField;
         }
 
         return table.findAll(findParams)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1018,6 +1018,49 @@ describe('index test', function () {
             });
         });
 
+        it('scans for aggregation of data', () => {
+            const testData = [
+                {
+                    templateId: 7,
+                    count: 5
+                },
+                {
+                    templateId: 9,
+                    count: 2
+                }
+            ];
+            const testInternal = [
+                {
+                    toJSON: sinon.stub().returns(testData[0])
+                },
+                {
+                    toJSON: sinon.stub().returns(testData[1])
+                }
+            ];
+
+            testParams.table = 'jobs';
+            testParams.aggregationField = 'templateId';
+            testParams.params = {
+                templateId: [7, 9, 10]
+            };
+
+            sequelizeTableMock.findAll.resolves(testInternal);
+
+            return datastore.scan(testParams).then((data) => {
+                assert.deepEqual(data, testData);
+                assert.calledWith(sequelizeTableMock.findAll, {
+                    where: {
+                        templateId: {
+                            IN: [7, 9, 10]
+                        }
+                    },
+                    order: [['id', 'DESC']],
+                    attributes: ['templateId', ['COUNT', 'count']],
+                    group: 'templateId'
+                });
+            });
+        });
+
         it('scans for some data with indexed params using range key', () => {
             const testData = [
                 {


### PR DESCRIPTION
## Context

This change is to improve api efficiency when querying for template popularity metrics.

## Objective

This PR adds the ability to do aggregation queries.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1091

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
