### PR TITLE
fix(1091): fix aggregation queries by deleting order by param

### DIFF
--- a/index.js
+++ b/index.js
@@ -561,6 +561,7 @@ class Squeakquel extends Datastore {
             );
 
             findParams.group = config.aggregationField;
+            delete findParams.order;
         }
 
         return table.findAll(findParams)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1054,7 +1054,6 @@ describe('index test', function () {
                             IN: [7, 9, 10]
                         }
                     },
-                    order: [['id', 'DESC']],
                     attributes: ['templateId', ['COUNT', 'count']],
                     group: 'templateId'
                 });


### PR DESCRIPTION
## Context

Need to remove the order by portion of aggregation queries so that they will work correctly in postgres. order by is defaulted to id (and then possibly updated to a different index field) in _scan, if you are not selecting this field in the aggregation query it breaks the query.

i.e. What the queries look like:

Before:
SELECT "templateId", COUNT("templateId") AS count FROM jobs AS jobs WHERE jobs."templateId" IN ('3','5') GROUP BY "templateId" ORDER BY "id";

After:
SELECT "templateId", COUNT("templateId") AS count FROM jobs AS jobs WHERE jobs."templateId" IN ('3','5') GROUP BY "templateId";

## Objective

Remove order from findParams; that is remove the order by portion of aggregation queries.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1091

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
