### PR TITLE
feat(1967): add ability to do raw queries. BREAKING CHANGE: pulling in new datastore-base version

### DIFF
--- a/index.js
+++ b/index.js
@@ -576,7 +576,7 @@ class Squeakquel extends Datastore {
      * @param  {Array<Object>} [config.queries]      Map of database type to query
      * @param  {String}        [config.table]        Table name
      * @param  {Object}        [config.replacements] Parameters to replace in the query
-     * @param  {Boolean}       [config.rawResponse]  Return raw response
+     * @param  {Boolean}       [config.rawResponse]  Return raw response without binding to model
      */
     _query(config) {
         const table = this.tables[config.table];

--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ function decodeFromDialect(dialect, content, model) {
     }
 
     const decodedValues = content.toJSON();
-
     const fields = model.base.describe().children;
 
     Object.keys(decodedValues).forEach((fieldName) => {

--- a/index.js
+++ b/index.js
@@ -580,8 +580,8 @@ class Squeakquel extends Datastore {
     _query(config) {
         const table = this.tables[config.table];
         const model = this.models[config.table];
-        const query = config.queries.find(q => q.dbType == this.client.getDialect()).query;
-        const queryParams = {replacements: config.replacements};
+        const query = config.queries.find(q => q.dbType === this.client.getDialect()).query;
+        const queryParams = { replacements: config.replacements };
 
         if (!config.rawResponse) {
             queryParams.model = this.client.models[config.table];

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mysql2": "^1.6.5",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
+    "rewire": "^4.0.1",
     "screwdriver-data-schema": "^19.1.1",
     "screwdriver-datastore-base": "^3.0.7",
     "screwdriver-logger": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pg-hstore": "^2.3.2",
     "rewire": "^4.0.1",
     "screwdriver-data-schema": "^19.1.1",
-    "screwdriver-datastore-base": "^3.0.7",
+    "screwdriver-datastore-base": "^4.0.0",
     "screwdriver-logger": "^1.0.0",
     "sequelize": "^5.3.0",
     "sqlite3": "^4.1.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1332,5 +1332,30 @@ describe('index test', function () {
                 revertdecodeFromDialect();
             });
         });
+
+        it('query fails when given an unknown table name', () => {
+            testParams.table = 'dne';
+
+            return datastore.query(testParams).then(() => {
+                throw new Error('Oops');
+            }).catch((err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.match(err.message, /Invalid table name/);
+            });
+        });
+
+        it('query fails when not given a matching query', () => {
+            testParams.queries = [{
+                dbType: 'dne',
+                query: 'dneQuery'
+            }];
+
+            return datastore.query(testParams).then(() => {
+                throw new Error('Oops');
+            }).catch((err) => {
+                assert.isOk(err, 'Error should be returned');
+                assert.match(err.message, /No query found for/);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Context

Need to add the ability to do raw queries to datastore so queries that are otherwise impossible to do through sequelize can be done.

## Objective

Add a query method to datastore.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1967

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
