### PR TITLE
fix(2212): sequelize version to 5.22.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "screwdriver-data-schema": "^20.0.0",
     "screwdriver-datastore-base": "^5.0.0",
     "screwdriver-logger": "^1.0.0",
-    "sequelize": "^6.3.4",
+    "sequelize": "^5.22.3",
     "sqlite3": "^4.1.0"
   }
 }


### PR DESCRIPTION
## Context
I want fix an issue with the template page not displaying anything.
https://github.com/screwdriver-cd/screwdriver/issues/2212.

## Objective
We previously updated to sequelize@6, but it seems that some support is missing.
https://github.com/screwdriver-cd/datastore-sequelize/commit/138131b0ee52a6301fb766237329d3cbc415bb69#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L58-R58

One way to deal with this is to revert to sequelize@5.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://www.npmjs.com/package/sequelize
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
