### PR TITLE
feat: remove expensive describe() fn calls and use fields property instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,10 +101,10 @@ function getSequelizeTypeFromJoi(dialect, type, rules) {
     const column = rules.filter(o => o.name === 'length' || o.name === 'max');
 
     if (column) {
-        const value = column.map(o => o.arg)[0] || column.map(o => o.args)[0];
+        const args = column.map(o => o.arg)[0] || column.map(o => o.args)[0];
 
-        if (value) {
-            length = value.limit ? value.limit : value;
+        if (args) {
+            length = args.limit;
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function decodeFromDialect(dialect, content, model) {
     }
 
     const decodedValues = content.toJSON();
-    const fields = model.base.describe().keys;
+    const fields = model.fields;
 
     Object.keys(decodedValues).forEach(fieldName => {
         const field = fields[fieldName] || {};
@@ -72,7 +72,7 @@ function encodeToDialect(dialect, content, model) {
             encodedObject[keyName] = promisedValues[index];
         });
 
-        const fields = model.base.describe().keys;
+        const fields = model.fields;
 
         encodedKeys.forEach(fieldName => {
             const field = fields[fieldName] || {};
@@ -190,7 +190,7 @@ class Squeakquel extends Datastore {
     _defineTable(modelName) {
         const schema = MODELS[modelName];
         const tableName = `${this.prefix}${schema.tableName}`;
-        const fields = schema.base.describe().keys;
+        const fields = schema.fields;
         const tableFields = {};
         const tableOptions = {
             timestamps: false,
@@ -198,7 +198,7 @@ class Squeakquel extends Datastore {
         };
 
         Object.keys(fields).forEach(fieldName => {
-            const field = fields[fieldName];
+            const field = fields[fieldName].describe();
 
             let rules;
 
@@ -395,7 +395,7 @@ class Squeakquel extends Datastore {
             return Promise.reject(new Error(`Invalid table name "${config.table}"`));
         }
 
-        const fields = model.base.describe().keys;
+        const fields = model.fields;
         const validFields = Object.keys(fields);
 
         if (config.paginate) {

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function decodeFromDialect(dialect, content, model) {
     const decodedValues = content.toJSON();
     const fields = model.base.describe().keys;
 
-    Object.keys(decodedValues).forEach((fieldName) => {
+    Object.keys(decodedValues).forEach(fieldName => {
         const field = fields[fieldName] || {};
         const fieldType = field.type;
 
@@ -64,7 +64,7 @@ function encodeToDialect(dialect, content, model) {
     const encodedKeys = Object.keys(content);
     const encodedValues = encodedKeys.map(keyName => content[keyName]);
 
-    return Promise.all(encodedValues).then((promisedValues) => {
+    return Promise.all(encodedValues).then(promisedValues => {
         const encodedObject = {};
 
         // Flatten into an object again
@@ -74,7 +74,7 @@ function encodeToDialect(dialect, content, model) {
 
         const fields = model.base.describe().keys;
 
-        encodedKeys.forEach((fieldName) => {
+        encodedKeys.forEach(fieldName => {
             const field = fields[fieldName] || {};
             const fieldType = field.type;
 
@@ -109,32 +109,32 @@ function getSequelizeTypeFromJoi(dialect, type, rules) {
     }
 
     switch (type) {
-    case 'string':
-        if (length) {
-            return Sequelize.STRING(length);
-        }
+        case 'string':
+            if (length) {
+                return Sequelize.STRING(length);
+            }
 
-        return Sequelize.TEXT;
-    case 'array':
-        return Sequelize.TEXT;
-    case 'object':
-        return Sequelize.TEXT('medium');
-    case 'date':
-        return Sequelize.DATE;
-    case 'number':
-        return Sequelize.DOUBLE;
-    case 'boolean':
-        return Sequelize.BOOLEAN;
-    case 'binary':
-        return Sequelize.BLOB;
-    case 'alternatives':
-        if (length) {
-            return Sequelize.STRING(length);
-        }
+            return Sequelize.TEXT;
+        case 'array':
+            return Sequelize.TEXT;
+        case 'object':
+            return Sequelize.TEXT('medium');
+        case 'date':
+            return Sequelize.DATE;
+        case 'number':
+            return Sequelize.DOUBLE;
+        case 'boolean':
+            return Sequelize.BOOLEAN;
+        case 'binary':
+            return Sequelize.BLOB;
+        case 'alternatives':
+            if (length) {
+                return Sequelize.STRING(length);
+            }
 
-        return Sequelize.TEXT('medium');
-    default:
-        return null;
+            return Sequelize.TEXT('medium');
+        default:
+            return null;
     }
 }
 
@@ -166,17 +166,12 @@ class Squeakquel extends Datastore {
         // It won't work if prefix is passed to Sequelize
         delete config.prefix;
 
-        this.client = new Sequelize(
-            config.database || 'screwdriver',
-            config.username,
-            config.password,
-            config
-        );
+        this.client = new Sequelize(config.database || 'screwdriver', config.username, config.password, config);
 
         this.tables = {};
         this.models = {};
 
-        MODEL_NAMES.forEach((modelName) => {
+        MODEL_NAMES.forEach(modelName => {
             const table = this._defineTable(modelName);
             const model = schemas.models[modelName];
 
@@ -202,7 +197,7 @@ class Squeakquel extends Datastore {
             indexes: schema.indexes
         };
 
-        Object.keys(fields).forEach((fieldName) => {
+        Object.keys(fields).forEach(fieldName => {
             const field = fields[fieldName];
 
             let rules;
@@ -217,11 +212,7 @@ class Squeakquel extends Datastore {
             }
 
             const output = {
-                type: getSequelizeTypeFromJoi(
-                    this.client.getDialect(),
-                    field.type,
-                    rules || []
-                )
+                type: getSequelizeTypeFromJoi(this.client.getDialect(), field.type, rules || [])
             };
 
             if (fieldName === 'id') {
@@ -301,9 +292,11 @@ class Squeakquel extends Datastore {
 
         return encodeToDialect(this.client.getDialect(), userData, model)
             .then(item => table.create(item))
-            .then(row => row.get({
-                plain: true
-            }));
+            .then(row =>
+                row.get({
+                    plain: true
+                })
+            );
     }
 
     /**
@@ -321,11 +314,13 @@ class Squeakquel extends Datastore {
             return Promise.reject(new Error(`Invalid table name "${config.table}"`));
         }
 
-        return table.destroy({
-            where: {
-                id: config.params.id
-            }
-        }).then(() => null);
+        return table
+            .destroy({
+                where: {
+                    id: config.params.id
+                }
+            })
+            .then(() => null);
     }
 
     /**
@@ -347,9 +342,11 @@ class Squeakquel extends Datastore {
         }
 
         return encodeToDialect(this.client.getDialect(), userData, model)
-            .then(item => table.update(item, {
-                where: { id }
-            }))
+            .then(item =>
+                table.update(item, {
+                    where: { id }
+                })
+            )
             .then(() => userData);
     }
 
@@ -407,7 +404,7 @@ class Squeakquel extends Datastore {
         }
 
         if (config.params && Object.keys(config.params).length > 0) {
-            Object.keys(config.params).forEach((paramName) => {
+            Object.keys(config.params).forEach(paramName => {
                 const paramValue = config.params[paramName];
 
                 if (Array.isArray(paramValue)) {
@@ -419,9 +416,7 @@ class Squeakquel extends Datastore {
                     if (this._fieldInvalid({ validFields, field: paramValue })) {
                         throw new Error(`Invalid distinct field "${paramValue}"`);
                     }
-                    findParams.attributes = [[
-                        Sequelize.fn('DISTINCT', Sequelize.col(paramValue)), paramValue
-                    ]];
+                    findParams.attributes = [[Sequelize.fn('DISTINCT', Sequelize.col(paramValue)), paramValue]];
                 } else {
                     if (this._fieldInvalid({ validFields, field: paramName })) {
                         throw new Error(`Invalid param "${paramName}"`);
@@ -429,8 +424,7 @@ class Squeakquel extends Datastore {
                     findParams.where[paramName] = paramValue;
                 }
 
-                const indexIndex = (model.indexes && model.rangeKeys)
-                    ? model.indexes.indexOf(paramName) : -1;
+                const indexIndex = model.indexes && model.rangeKeys ? model.indexes.indexOf(paramName) : -1;
 
                 if (indexIndex >= 0) {
                     sortKey = model.rangeKeys[indexIndex];
@@ -439,9 +433,10 @@ class Squeakquel extends Datastore {
         }
 
         if (config.search && config.search.field && config.search.keyword) {
-            const searchKey = this.client.getDialect() === 'postgres'
-                ? { [Sequelize.Op.iLike]: config.search.keyword }
-                : { [Sequelize.Op.like]: config.search.keyword };
+            const searchKey =
+                this.client.getDialect() === 'postgres'
+                    ? { [Sequelize.Op.iLike]: config.search.keyword }
+                    : { [Sequelize.Op.like]: config.search.keyword };
 
             // If field is array, search for keyword in all fields
             if (Array.isArray(config.search.field)) {
@@ -449,7 +444,7 @@ class Squeakquel extends Datastore {
                     [Sequelize.Op.or]: []
                 };
 
-                config.search.field.forEach((field) => {
+                config.search.field.forEach(field => {
                     if (this._fieldInvalid({ validFields, field })) {
                         throw new Error(`Invalid search field "${field}"`);
                     }
@@ -500,7 +495,7 @@ class Squeakquel extends Datastore {
 
             // every other selected field must be aggregated so database engine won't complain
             // use "MAX" since the nature of this table is append-only
-            findParams.attributes = includedFields.map((field) => {
+            findParams.attributes = includedFields.map(field => {
                 let col = Sequelize.col(field);
 
                 // Temporary treatment to show correct trusted value.
@@ -511,19 +506,18 @@ class Squeakquel extends Datastore {
 
                     subCol = Sequelize.cast(subCol, 'integer');
 
-                    const subQueryForTrusted = this.client.dialect
-                        .QueryGenerator.selectQuery(tableName, {
-                            tableAs: 't1',
-                            attributes: [Sequelize.fn('MAX', subCol)],
-                            where: {
-                                name: {
-                                    [Sequelize.Op.eq]: Sequelize.col(`${tableName}.name`)
-                                },
-                                namespace: {
-                                    [Sequelize.Op.eq]: Sequelize.col(`${tableName}.namespace`)
-                                }
+                    const subQueryForTrusted = this.client.dialect.QueryGenerator.selectQuery(tableName, {
+                        tableAs: 't1',
+                        attributes: [Sequelize.fn('MAX', subCol)],
+                        where: {
+                            name: {
+                                [Sequelize.Op.eq]: Sequelize.col(`${tableName}.name`)
+                            },
+                            namespace: {
+                                [Sequelize.Op.eq]: Sequelize.col(`${tableName}.namespace`)
                             }
-                        }).slice(0, -1);
+                        }
+                    }).slice(0, -1);
 
                     col = this.client.literal(`(${subQueryForTrusted})`);
                 }
@@ -540,7 +534,7 @@ class Squeakquel extends Datastore {
 
             const where = { id: { [Sequelize.Op.gte]: Sequelize.col(`${tableName}.id`) } };
 
-            config.groupBy.forEach((v) => {
+            config.groupBy.forEach(v => {
                 where[v] = { [Sequelize.Op.eq]: Sequelize.col(`${tableName}.${v}`) };
             });
 
@@ -566,18 +560,15 @@ class Squeakquel extends Datastore {
             }
 
             findParams.attributes.push(config.aggregationField);
-            findParams.attributes.push([
-                Sequelize.fn('COUNT', Sequelize.col(config.aggregationField)),
-                'count']
-            );
+            findParams.attributes.push([Sequelize.fn('COUNT', Sequelize.col(config.aggregationField)), 'count']);
 
             findParams.group = config.aggregationField;
             delete findParams.order;
         }
 
-        return table.findAll(findParams)
-            .then(items => Promise.all(items.map(item =>
-                decodeFromDialect(this.client.getDialect(), item, model))));
+        return table
+            .findAll(findParams)
+            .then(items => Promise.all(items.map(item => decodeFromDialect(this.client.getDialect(), item, model))));
     }
 
     /**
@@ -597,7 +588,8 @@ class Squeakquel extends Datastore {
 
         if (!table) {
             return Promise.reject(new Error(`Invalid table name "${config.table}"`));
-        } else if (!query) {
+        }
+        if (!query) {
             return Promise.reject(new Error(`No query found for "${dialect}" database`));
         }
 
@@ -606,7 +598,7 @@ class Squeakquel extends Datastore {
             queryParams.mapToModel = true;
         }
 
-        return table.sequelize.query(query.query, queryParams).then((data) => {
+        return table.sequelize.query(query.query, queryParams).then(data => {
             if (!config.rawResponse) {
                 data.map(d => decodeFromDialect(this.client.getDialect(), d, model));
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-sequelize",
-  "version": "4.0.0",
+  "version": "7.0.0",
   "description": "Datastore implementation for mysql, postgres, sqlite3, and mssql",
   "main": "index.js",
   "scripts": {
@@ -40,22 +40,22 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^4.19.1",
-    "eslint-config-screwdriver": "^3.0.1",
+    "eslint": "^7.7.0",
+    "eslint-config-screwdriver": "^5.0.4",
     "mocha": "^8.0.1",
     "mockery": "^2.1.0",
     "rewire": "^5.0.0",
-    "sinon": "^2.3.2"
+    "sinon": "^9.0.3"
   },
   "dependencies": {
     "joi": "^17.2.0",
-    "mysql2": "^1.6.5",
+    "mysql2": "^2.1.0",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
-    "screwdriver-datastore-base": "git://github.com/screwdriver-cd/datastore-base.git#hapi-v19",
+    "screwdriver-data-schema": "^20.0.0",
+    "screwdriver-datastore-base": "^5.0.0",
     "screwdriver-logger": "^1.0.0",
-    "sequelize": "^5.3.0",
+    "sequelize": "^6.3.4",
     "sqlite3": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive --timeout 4000 --retries 1 --exit --color true",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -39,21 +39,21 @@
     }
   },
   "devDependencies": {
+    "@hapi/joi": "^17.1.1",
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^6.0.0",
-    "joi": "^13.7.0",
+    "mocha": "^8.0.1",
     "mockery": "^2.1.0",
+    "rewire": "^5.0.0",
     "sinon": "^2.3.2"
   },
   "dependencies": {
     "mysql2": "^1.6.5",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
-    "rewire": "^5.0.0",
-    "screwdriver-data-schema": "^19.1.1",
-    "screwdriver-datastore-base": "^4.0.0",
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
+    "screwdriver-datastore-base": "git://github.com/screwdriver-cd/datastore-base.git#hapi-v19",
     "screwdriver-logger": "^1.0.0",
     "sequelize": "^5.3.0",
     "sqlite3": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-sequelize",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Datastore implementation for mysql, postgres, sqlite3, and mssql",
   "main": "index.js",
   "scripts": {
@@ -39,7 +39,6 @@
     }
   },
   "devDependencies": {
-    "@hapi/joi": "^17.1.1",
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
@@ -49,6 +48,7 @@
     "sinon": "^2.3.2"
   },
   "dependencies": {
+    "joi": "^17.2.0",
     "mysql2": "^1.6.5",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Datastore implementation for mysql, postgres, sqlite3, and mssql",
   "main": "index.js",
   "scripts": {
-    "pretest": "eslint .",
+    "pretest": "eslint . --quiet",
     "test": "mocha --recursive --timeout 4000 --retries 1 --exit --color true",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
@@ -52,7 +52,7 @@
     "mysql2": "^2.1.0",
     "pg": "^6.2.3",
     "pg-hstore": "^2.3.2",
-    "screwdriver-data-schema": "^20.0.0",
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#perf-fix",
     "screwdriver-datastore-base": "^5.0.0",
     "screwdriver-logger": "^1.0.0",
     "sequelize": "^6.3.4",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,22 +12,24 @@ const rewire = require('rewire');
 sinon.assert.expose(assert, { prefix: '' });
 
 describe('index test', function() {
+    const model = {
+        id: joi.string().length(40),
+        str: joi.string(),
+        date: joi.date(),
+        num: joi.number(),
+        bool: joi.boolean(),
+        bin: joi.binary(),
+        arr: joi.array(),
+        obj: joi.object(),
+        any: joi.any(),
+        namespace: joi.string(),
+        name: joi.string()
+    };
     const dataSchemaMock = {
         models: {
             pipeline: {
-                base: joi.object({
-                    id: joi.string().length(40),
-                    str: joi.string(),
-                    date: joi.date(),
-                    num: joi.number(),
-                    bool: joi.boolean(),
-                    bin: joi.binary(),
-                    arr: joi.array(),
-                    obj: joi.object(),
-                    any: joi.any(),
-                    namespace: joi.string(),
-                    name: joi.string()
-                }),
+                base: joi.object(model),
+                fields: model,
                 tableName: 'pipelines',
                 keys: ['num', 'str'],
                 indexes: ['str']
@@ -37,6 +39,10 @@ describe('index test', function() {
                     id: joi.string().length(40),
                     name: joi.string()
                 }),
+                fields: {
+                    id: joi.string().length(40),
+                    name: joi.string()
+                },
                 tableName: 'jobs',
                 keys: ['name'],
                 indexes: ['name'],
@@ -48,6 +54,11 @@ describe('index test', function() {
                     src: joi.alternatives().try(joi.object().max(64), joi.string().max(64)),
                     dest: joi.alternatives().try(joi.object().max(64), joi.string().max(64))
                 }),
+                fields: {
+                    id: joi.string().length(40),
+                    src: joi.alternatives().try(joi.object().max(64), joi.string().max(64)),
+                    dest: joi.alternatives().try(joi.object().max(64), joi.string().max(64))
+                },
                 tableName: 'triggers',
                 keys: ['src', 'dest'],
                 indexes: ['dest', 'src']

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const Sequelize = require('sequelize');
 const rewire = require('rewire');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@
 const assert = require('chai').assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
-const joi = require('joi');
+const joi = require('@hapi/joi');
 const Sequelize = require('sequelize');
 const rewire = require('rewire');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,7 @@ const rewire = require('rewire');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('index test', function () {
+describe('index test', function() {
     const dataSchemaMock = {
         models: {
             pipeline: {
@@ -45,12 +45,8 @@ describe('index test', function () {
             trigger: {
                 base: joi.object({
                     id: joi.string().length(40),
-                    src: joi.alternatives().try(
-                        joi.object().max(64),
-                        joi.string().max(64)),
-                    dest: joi.alternatives().try(
-                        joi.object().max(64),
-                        joi.string().max(64))
+                    src: joi.alternatives().try(joi.object().max(64), joi.string().max(64)),
+                    dest: joi.alternatives().try(joi.object().max(64), joi.string().max(64))
                 }),
                 tableName: 'triggers',
                 keys: ['src', 'dest'],
@@ -149,7 +145,7 @@ describe('index test', function () {
 
     beforeEach(() => {
         // Reset mocks
-        Object.keys(sequelizeTableMock).forEach((key) => {
+        Object.keys(sequelizeTableMock).forEach(key => {
             if (key === 'sequelize') {
                 sequelizeTableMock[key].query.reset();
             } else {
@@ -258,7 +254,7 @@ describe('index test', function () {
 
             sequelizeClientMock.sync.resolves('moo');
 
-            return datastore.setup(ddlSyncEnabled).then((data) => {
+            return datastore.setup(ddlSyncEnabled).then(data => {
                 assert.deepEqual(data, 'moo');
             });
         });
@@ -268,11 +264,14 @@ describe('index test', function () {
 
             sequelizeClientMock.sync.resolves(Promise.resolve());
 
-            return datastore.setup(ddlSyncEnabled).then(() => {
-                // do nothing
-            }).catch(() => {
-                assert.fail('this should not get here');
-            });
+            return datastore
+                .setup(ddlSyncEnabled)
+                .then(() => {
+                    // do nothing
+                })
+                .catch(() => {
+                    assert.fail('this should not get here');
+                });
         });
     });
 
@@ -305,7 +304,7 @@ describe('index test', function () {
             sequelizeTableMock.findByPk.resolves(responseMock);
             responseMock.toJSON.returns(testData);
 
-            return datastore.get(testParams).then((data) => {
+            return datastore.get(testParams).then(data => {
                 assert.deepEqual(data, realData);
                 assert.calledWith(sequelizeTableMock.findByPk, testParams.params.id);
             });
@@ -340,7 +339,7 @@ describe('index test', function () {
             sequelizeTableMock.findOne.resolves(responseMock);
             responseMock.toJSON.returns(testData);
 
-            return datastore.get(testParams).then((data) => {
+            return datastore.get(testParams).then(data => {
                 assert.deepEqual(data, realData);
                 assert.calledWith(sequelizeTableMock.findOne, {
                     where: testParams.params
@@ -351,44 +350,51 @@ describe('index test', function () {
         it('gracefully understands that no one is returned when it does not exist', () => {
             sequelizeTableMock.findByPk.resolves(null);
 
-            return datastore.get({
-                table: 'pipelines',
-                params: {
-                    id: 'someId'
-                }
-            }).then(data => assert.isNull(data));
+            return datastore
+                .get({
+                    table: 'pipelines',
+                    params: {
+                        id: 'someId'
+                    }
+                })
+                .then(data => assert.isNull(data));
         });
 
         it('fails when given an unknown table name', () =>
-            datastore.get({
-                table: 'tableUnicorn',
-                params: {
-                    id: 'doesNotMatter'
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            })
-        );
+            datastore
+                .get({
+                    table: 'tableUnicorn',
+                    params: {
+                        id: 'doesNotMatter'
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                }));
 
         it('fails when it encounters an error', () => {
             const testError = new Error('errorCommunicatingToApi');
 
             sequelizeTableMock.findByPk.rejects(testError);
 
-            return datastore._get({
-                table: 'pipelines',
-                params: {
-                    id: 'someId'
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.equal(err.message, testError.message);
-            });
+            return datastore
+                ._get({
+                    table: 'pipelines',
+                    params: {
+                        id: 'someId'
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.equal(err.message, testError.message);
+                });
         });
     });
 
@@ -407,23 +413,25 @@ describe('index test', function () {
             expectedRow.get.returns(expectedResult);
             sequelizeTableMock.create.resolves(expectedRow);
 
-            return datastore.save({
-                table: 'pipelines',
-                params: {
-                    key: 'value',
-                    arr: [1, 2, 3],
-                    obj: {
-                        a: 'b'
+            return datastore
+                .save({
+                    table: 'pipelines',
+                    params: {
+                        key: 'value',
+                        arr: [1, 2, 3],
+                        obj: {
+                            a: 'b'
+                        }
                     }
-                }
-            }).then((data) => {
-                assert.deepEqual(data, expectedResult);
-                assert.calledWith(sequelizeTableMock.create, {
-                    key: 'value',
-                    arr: '[1,2,3]',
-                    obj: '{"a":"b"}'
+                })
+                .then(data => {
+                    assert.deepEqual(data, expectedResult);
+                    assert.calledWith(sequelizeTableMock.create, {
+                        key: 'value',
+                        arr: '[1,2,3]',
+                        obj: '{"a":"b"}'
+                    });
                 });
-            });
         });
 
         it('fails when it encounters an error', () => {
@@ -431,34 +439,41 @@ describe('index test', function () {
 
             sequelizeTableMock.create.rejects(testError);
 
-            return datastore.save({
-                table: 'pipelines',
-                params: {
-                    id: 'doesNotMatter',
-                    data: {}
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }, (err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.equal(err.message, testError.message);
-            });
+            return datastore
+                .save({
+                    table: 'pipelines',
+                    params: {
+                        id: 'doesNotMatter',
+                        data: {}
+                    }
+                })
+                .then(
+                    () => {
+                        throw new Error('Oops');
+                    },
+                    err => {
+                        assert.isOk(err, 'Error should be returned');
+                        assert.equal(err.message, testError.message);
+                    }
+                );
         });
 
         it('fails when given an unknown table name', () =>
-            datastore.save({
-                table: 'doesNotExist',
-                params: {
-                    id: 'doesNotMatter',
-                    data: {}
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            })
-        );
+            datastore
+                .save({
+                    table: 'doesNotExist',
+                    params: {
+                        id: 'doesNotMatter',
+                        data: {}
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                }));
     });
 
     describe('remove', () => {
@@ -472,7 +487,7 @@ describe('index test', function () {
 
             sequelizeTableMock.destroy.resolves(null);
 
-            return datastore.remove(testParams).then((data) => {
+            return datastore.remove(testParams).then(data => {
                 assert.isNull(data);
                 assert.calledWith(sequelizeTableMock.destroy, {
                     where: {
@@ -483,35 +498,40 @@ describe('index test', function () {
         });
 
         it('fails when given an unknown table name', () =>
-            datastore.remove({
-                table: 'tableUnicorn',
-                params: {
-                    id: 'doesNotMatter'
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            })
-        );
+            datastore
+                .remove({
+                    table: 'tableUnicorn',
+                    params: {
+                        id: 'doesNotMatter'
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                }));
 
         it('fails when it encounters an error', () => {
             const testError = new Error('errorCommunicatingToApi');
 
             sequelizeTableMock.destroy.rejects(testError);
 
-            return datastore.remove({
-                table: 'pipelines',
-                params: {
-                    id: 'someId'
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, testError.message);
-            });
+            return datastore
+                .remove({
+                    table: 'pipelines',
+                    params: {
+                        id: 'someId'
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, testError.message);
+                });
         });
     });
 
@@ -525,53 +545,60 @@ describe('index test', function () {
 
             sequelizeTableMock.update.resolves();
 
-            return datastore.update({
-                table: 'pipelines',
-                params: {
-                    id,
-                    targetKey: 'updatedValue'
-                }
-            }).then((data) => {
-                assert.deepEqual(data, expectedResult);
-                assert.calledWith(sequelizeTableMock.update, {
-                    id,
-                    targetKey: 'updatedValue'
+            return datastore
+                .update({
+                    table: 'pipelines',
+                    params: {
+                        id,
+                        targetKey: 'updatedValue'
+                    }
+                })
+                .then(data => {
+                    assert.deepEqual(data, expectedResult);
+                    assert.calledWith(sequelizeTableMock.update, {
+                        id,
+                        targetKey: 'updatedValue'
+                    });
                 });
-            });
         });
 
         it('fails when given an unknown table name', () =>
-            datastore.update({
-                table: 'doesNotExist',
-                params: {
-                    id: 'doesNotMatter',
-                    data: {}
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            })
-        );
+            datastore
+                .update({
+                    table: 'doesNotExist',
+                    params: {
+                        id: 'doesNotMatter',
+                        data: {}
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                }));
 
         it('fails when it encounters an error', () => {
             const testError = new Error('testError');
 
             sequelizeTableMock.update.rejects(testError);
 
-            return datastore.update({
-                table: 'pipelines',
-                params: {
-                    id: 'doesNotMatter',
-                    data: {}
-                }
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.equal(err.message, testError.message);
-            });
+            return datastore
+                .update({
+                    table: 'pipelines',
+                    params: {
+                        id: 'doesNotMatter',
+                        data: {}
+                    }
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.equal(err.message, testError.message);
+                });
         });
     });
 
@@ -606,7 +633,7 @@ describe('index test', function () {
 
             sequelizeTableMock.findAll.resolves(testInternal);
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {},
@@ -639,7 +666,7 @@ describe('index test', function () {
 
             sequelizeTableMock.findAll.resolves(testInternal);
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {},
@@ -670,7 +697,7 @@ describe('index test', function () {
 
             sequelizeTableMock.findAll.resolves(testInternal);
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {},
@@ -706,7 +733,7 @@ describe('index test', function () {
             sequelizeTableMock.findAll.resolves(testInternal);
             testParams.sortBy = 'str';
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {},
@@ -743,7 +770,7 @@ describe('index test', function () {
                 keyword: '%foo%'
             };
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: { name: { LIKE: '%foo%' } },
@@ -782,7 +809,7 @@ describe('index test', function () {
 
             sequelizeClientMock.getDialect = sinon.stub().returns('postgres');
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: { name: { ILIKE: '%foo%' } },
@@ -827,14 +854,11 @@ describe('index test', function () {
                 keyword: '%foo%'
             };
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {
-                        OR: [
-                            { namespace: { LIKE: '%foo%' } },
-                            { name: { LIKE: '%foo%' } }
-                        ]
+                        OR: [{ namespace: { LIKE: '%foo%' } }, { name: { LIKE: '%foo%' } }]
                     },
                     order: [['id', 'DESC']]
                 });
@@ -847,12 +871,15 @@ describe('index test', function () {
                 keyword: '%foo%'
             };
 
-            return datastore.scan(testParams).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid search field "banana"/);
-            });
+            return datastore
+                .scan(testParams)
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid search field "banana"/);
+                });
         });
 
         it('throws error if search field in field array does not exist in schema', () => {
@@ -861,23 +888,29 @@ describe('index test', function () {
                 keyword: '%foo%'
             };
 
-            return datastore.scan(testParams).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid search field "banana"/);
-            });
+            return datastore
+                .scan(testParams)
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid search field "banana"/);
+                });
         });
 
         it('throws error if sortBy does not exist in schema', () => {
             testParams.sortBy = 'banana';
 
-            return datastore.scan(testParams).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid sortBy "banana"/);
-            });
+            return datastore
+                .scan(testParams)
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid sortBy "banana"/);
+                });
         });
 
         it('scans for some data with params', () => {
@@ -907,7 +940,7 @@ describe('index test', function () {
 
             sequelizeTableMock.findAll.resolves(testInternal);
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {
@@ -926,12 +959,15 @@ describe('index test', function () {
                 foo: 'banana'
             };
 
-            return datastore.scan(testParams).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid param "foo"/);
-            });
+            return datastore
+                .scan(testParams)
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid param "foo"/);
+                });
         });
 
         it('scans for some data with distinct params', () => {
@@ -962,14 +998,11 @@ describe('index test', function () {
 
             sequelizeTableMock.findAll.resolves(testInternal);
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {},
-                    attributes: [[
-                        sequelizeMock.fn('DISTINCT', sequelizeMock.col('namespace')),
-                        'namespace'
-                    ]],
+                    attributes: [[sequelizeMock.fn('DISTINCT', sequelizeMock.col('namespace')), 'namespace']],
                     order: [['id', 'DESC']]
                 });
             });
@@ -980,12 +1013,15 @@ describe('index test', function () {
                 distinct: 'banana'
             };
 
-            return datastore.scan(testParams).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid distinct field "banana"/);
-            });
+            return datastore
+                .scan(testParams)
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid distinct field "banana"/);
+                });
         });
 
         it('scans for some data with indexed params', () => {
@@ -1015,7 +1051,7 @@ describe('index test', function () {
 
             sequelizeTableMock.findAll.resolves(testInternal);
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {
@@ -1057,7 +1093,7 @@ describe('index test', function () {
 
             sequelizeTableMock.findAll.resolves(testInternal);
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {
@@ -1099,7 +1135,7 @@ describe('index test', function () {
 
             sequelizeTableMock.findAll.resolves(testInternal);
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.deepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     where: {
@@ -1140,15 +1176,17 @@ describe('index test', function () {
             testParams.table = 'jobs';
             testParams.exclude = ['id'];
             testParams.groupBy = ['key'];
-            sequelizeQueryGeneratorMock.selectQuery.withArgs('jobs', {
-                tableAs: 't',
-                attributes: ['MAX'],
-                where: { id: { GTE: 'col' }, key: { EQ: 'col' } }
-            }).returns('subQuery;');
+            sequelizeQueryGeneratorMock.selectQuery
+                .withArgs('jobs', {
+                    tableAs: 't',
+                    attributes: ['MAX'],
+                    where: { id: { GTE: 'col' }, key: { EQ: 'col' } }
+                })
+                .returns('subQuery;');
             sequelizeClientMock.literal.withArgs('(subQuery)').returns('literal');
             sequelizeTableMock.findAll.resolves(testInternal);
 
-            return datastore.scan(testParams).then((data) => {
+            return datastore.scan(testParams).then(data => {
                 assert.notDeepEqual(data, testData);
                 assert.calledWith(sequelizeTableMock.findAll, {
                     attributes: [['col', 'name']],
@@ -1161,14 +1199,17 @@ describe('index test', function () {
         it('fails when given an unknown table name', () => {
             sequelizeTableMock.findAll.rejects(new Error('cannot find entries in table'));
 
-            return datastore._scan({
-                table: 'tableUnicorn'
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            });
+            return datastore
+                ._scan({
+                    table: 'tableUnicorn'
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                });
         });
 
         it('fails when it encounters an error', () => {
@@ -1176,14 +1217,17 @@ describe('index test', function () {
 
             sequelizeTableMock.findAll.rejects(testError);
 
-            return datastore._scan({
-                table: 'pipelines'
-            }).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, testError.message);
-            });
+            return datastore
+                ._scan({
+                    table: 'pipelines'
+                })
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, testError.message);
+                });
         });
 
         it('scans for data within date range', () => {
@@ -1302,10 +1346,7 @@ describe('index test', function () {
 
         it('query without raw response', () => {
             const testData = [{ id: 1, value: 'val' }];
-            const revertdecodeFromDialect = Datastore.__set__(
-                'decodeFromDialect',
-                sinon.stub().returns({})
-            );
+            const revertdecodeFromDialect = Datastore.__set__('decodeFromDialect', sinon.stub().returns({}));
 
             sequelizeClientMock.getDialect = sinon.stub().returns('postgres');
             sequelizeTableMock.sequelize.query.resolves(testData);
@@ -1336,26 +1377,34 @@ describe('index test', function () {
         it('query fails when given an unknown table name', () => {
             testParams.table = 'dne';
 
-            return datastore.query(testParams).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /Invalid table name/);
-            });
+            return datastore
+                .query(testParams)
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /Invalid table name/);
+                });
         });
 
         it('query fails when not given a matching query', () => {
-            testParams.queries = [{
-                dbType: 'dne',
-                query: 'dneQuery'
-            }];
+            testParams.queries = [
+                {
+                    dbType: 'dne',
+                    query: 'dneQuery'
+                }
+            ];
 
-            return datastore.query(testParams).then(() => {
-                throw new Error('Oops');
-            }).catch((err) => {
-                assert.isOk(err, 'Error should be returned');
-                assert.match(err.message, /No query found for/);
-            });
+            return datastore
+                .query(testParams)
+                .then(() => {
+                    throw new Error('Oops');
+                })
+                .catch(err => {
+                    assert.isOk(err, 'Error should be returned');
+                    assert.match(err.message, /No query found for/);
+                });
         });
     });
 });


### PR DESCRIPTION
## Context

[Sequelize](https://github.com/screwdriver-cd/datastore-sequelize/blob/b4609dc1ccb38888b26afc2f048f5f9cec6b6bb5/index.js#L27) library uses joi.object().describe() to get all the keys that are there in the model, profiling the sd node process has showed that this heavily used function takes up a lot of the processing time due to the nature of it describe a huge joi object on the entire model which leads to performance issues. Solution to fix this is to get rid of it as it seems unnecessary to use the entire nested object here as we only want to fetch the type of the properties.

## Objective

This PR removes the use of .describe() on entire model objects and instead uses the fields property where required to avoid any querying.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2216

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
