### PR TITLE
fix(2267): use eq instead of ilike for integer keyword

### DIFF
--- a/index.js
+++ b/index.js
@@ -433,7 +433,7 @@ class Squeakquel extends Datastore {
         }
 
         if (config.search && config.search.field && config.search.keyword) {
-            const searchOperator = this.client.getDialect() === 'postgres' ? Sequelize.Op.iLike : Sequelize.Op.like;
+            let searchOperator = this.client.getDialect() === 'postgres' ? Sequelize.Op.iLike : Sequelize.Op.like;
 
             // If field or keyword is array, search for all keywords in all fields
             if (Array.isArray(config.search.field) || Array.isArray(config.search.keyword)) {
@@ -445,6 +445,8 @@ class Squeakquel extends Datastore {
                 findParams.where = {
                     [Sequelize.Op.or]: []
                 };
+
+                searchOperator = Number.isInteger(searchKeywords[0]) ? Sequelize.Op.eq : searchOperator;
 
                 searchFields.forEach(field => {
                     if (this._fieldInvalid({ validFields, field })) {


### PR DESCRIPTION
## Context

Query fails for postgress when using `ilke` symbol for integer keyword
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

Use eq symbol instead
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://github.com/screwdriver-cd/screwdriver/issues/2267
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
