### PR TITLE
fix(2312): add ability to return total record count in scan

### DIFF
--- a/index.js
+++ b/index.js
@@ -370,7 +370,7 @@ class Squeakquel extends Datastore {
      * @param  {Object}         [config.paginate]         Pagination parameters
      * @param  {Number}         [config.paginate.count]   Number of items per page
      * @param  {Number}         [config.paginate.page]    Specific page of the set to return
-     * @param  {Boolean}        [config.getCount]         Get total count of record matching query criteria 
+     * @param  {Boolean}        [config.getCount]         Get total count of record matching query criteria
      * @param  {Object}         [config.params]           index => values to query on
      * @param  {String}         [config.params.distinct]  Field to return distinct rows on
      * @param  {Object}         [config.search]           Search parameters

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1370,7 +1370,7 @@ describe('index test', function() {
             });
         });
 
-        it.only('scans for count and data when getCount was passed in', () => {
+        it('scans for count and data when getCount was passed in', () => {
             const testData = {
                 count: 2,
                 rows: [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -93,6 +93,7 @@ describe('index test', function() {
             create: sinon.stub(),
             destroy: sinon.stub(),
             findAll: sinon.stub(),
+            findAndCountAll: sinon.stub(),
             findByPk: sinon.stub(),
             findOne: sinon.stub(),
             update: sinon.stub(),
@@ -1364,6 +1365,47 @@ describe('index test', function() {
                             LTE: testParams.endTime
                         }
                     },
+                    order: [['id', 'DESC']]
+                });
+            });
+        });
+
+        it.only('scans for count and data when getCount was passed in', () => {
+            const testData = {
+                count: 2,
+                rows: [
+                    {
+                        id: 'data1',
+                        key: 'value1'
+                    },
+                    {
+                        id: 'data2',
+                        key: 'value2'
+                    }
+                ]
+            };
+            const testInternal = {
+                count: 2,
+                rows: [
+                    {
+                        toJSON: sinon.stub().returns(testData.rows[0])
+                    },
+                    {
+                        toJSON: sinon.stub().returns(testData.rows[1])
+                    }
+                ]
+            };
+
+            sequelizeTableMock.findAndCountAll.resolves(testInternal);
+            sequelizeTableMock.findAll.resolves([]);
+            testParams.table = 'jobs';
+            testParams.getCount = true;
+
+            return datastore.scan(testParams).then(data => {
+                assert.notCalled(sequelizeTableMock.findAll);
+                assert.deepEqual(data, testData);
+                assert.calledWith(sequelizeTableMock.findAndCountAll, {
+                    where: {},
                     order: [['id', 'DESC']]
                 });
             });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
It would be nice to return total count in addition to paginated content.
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
add support to return total count
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2312
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
