### PR TITLE
fix(2312): scan OR fields should not overwrite AND fields

### DIFF
--- a/index.js
+++ b/index.js
@@ -444,6 +444,7 @@ class Squeakquel extends Datastore {
                     : [config.search.keyword];
 
                 findParams.where = {
+                    ...findParams.where,
                     [Sequelize.Op.or]: []
                 };
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
currently scan query with OR field will overwrite AND fields
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
AND fields should not be overwritten
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2312
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
