### PR TITLE
fix(2526): fix model lookup when prefix is used.

### DIFF
--- a/index.js
+++ b/index.js
@@ -622,7 +622,7 @@ class Squeakquel extends Datastore {
         }
 
         if (!config.rawResponse) {
-            queryParams.model = this.client.models[config.table];
+            queryParams.model = this.client.models[`${this.prefix}${config.table}`];
             queryParams.mapToModel = true;
         }
 


### PR DESCRIPTION



## Context

Sequalize model name is set as the table name. So when Sequalize model look happens
prefix must be used.
Sequalize model names are not the same as SD Model names.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://github.com/screwdriver-cd/screwdriver/issues/2526

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
