### PR TITLE
feat(2862): Return aggregation value as number instead as string for PostgreSQL

### DIFF
--- a/index.js
+++ b/index.js
@@ -564,7 +564,7 @@ class Squeakquel extends Datastore {
                 let col = Sequelize.col(field);
 
                 // Temporary treatment to show correct trusted value.
-                // This subQuery is used on fiels of SELECT clause.
+                // This subQuery is used on fields of SELECT clause.
                 // This needs to delete after the trusted table generated.
                 if (field === 'trusted') {
                     let subCol = Sequelize.col('trusted');
@@ -625,9 +625,15 @@ class Squeakquel extends Datastore {
             }
 
             findParams.attributes.push(config.aggregationField);
-            findParams.attributes.push([Sequelize.fn('COUNT', Sequelize.col(config.aggregationField)), 'count']);
+
+            if (this.client.getDialect() === 'postgres') {
+                findParams.attributes.push([Sequelize.literal(`COUNT("${config.aggregationField}")::int`), 'count']);
+            } else {
+                findParams.attributes.push([Sequelize.fn('COUNT', Sequelize.col(config.aggregationField)), 'count']);
+            }
 
             findParams.group = config.aggregationField;
+
             delete findParams.order;
         }
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const Sequelize = require('sequelize');
 const MODELS = schemas.models;
 const MODEL_NAMES = Object.keys(MODELS);
 const logger = require('screwdriver-logger');
+const pg = require('pg');
 
 /**
  * Converts data from the value stored in the datastore
@@ -178,6 +179,8 @@ class Squeakquel extends Datastore {
      */
     constructor(config = {}) {
         super(config);
+
+        pg.defaults.parseInt8 = true;
 
         this.slowlogThreshold = config.slowlogThreshold || 1000;
 
@@ -625,15 +628,9 @@ class Squeakquel extends Datastore {
             }
 
             findParams.attributes.push(config.aggregationField);
-
-            if (this.client.getDialect() === 'postgres') {
-                findParams.attributes.push([Sequelize.literal(`COUNT("${config.aggregationField}")::int`), 'count']);
-            } else {
-                findParams.attributes.push([Sequelize.fn('COUNT', Sequelize.col(config.aggregationField)), 'count']);
-            }
+            findParams.attributes.push([Sequelize.fn('COUNT', Sequelize.col(config.aggregationField)), 'count']);
 
             findParams.group = config.aggregationField;
-
             delete findParams.order;
         }
 


### PR DESCRIPTION
## Context

In PostgreSQL, `count()` returns of type `bigint`.
Sequelize uses [Node Postgres](https://node-postgres.com/) under the hood to interface with PostgreSQL database.
By default, Node Postgres casts `bigint` to `string`.
https://github.com/brianc/node-pg-types/blob/master/lib/binaryParsers.js#L105
https://github.com/charmander/pg-int8

Changes made in this PR https://github.com/screwdriver-cd/ui/pull/937 to display aggregated usage metrics across all the template versions assumes API always returns the count as number.
This works as expected for MySQL.
For PostgreSQL, the values are concatenated which results in incorrect values displayed in the UI.
![image](https://github.com/screwdriver-cd/datastore-sequelize/assets/2124590/b3f145b1-aa54-4307-9f4b-e331dd56a768)


## Objective
Configure Node Postgres not to cast `bigint` to `string`.
https://github.com/brianc/node-postgres/pull/427
 

## References

https://github.com/screwdriver-cd/screwdriver/issues/2862
https://stackoverflow.com/questions/66389300/postgres-cast-count-as-integer

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
