### PR TITLE
feat: Add notILike and notLike to search

### DIFF
--- a/index.js
+++ b/index.js
@@ -488,6 +488,11 @@ class Squeakquel extends Datastore {
         if (config.search && config.search.field && config.search.keyword) {
             let searchOperator = this.client.getDialect() === 'postgres' ? Sequelize.Op.iLike : Sequelize.Op.like;
 
+            // If flag is set, use NOT ILIKE and NOT LIKE
+            if (config.search.inverse) {
+                searchOperator = this.client.getDialect() === 'postgres' ? Sequelize.Op.notILike : Sequelize.Op.notLike;
+            }
+
             // If field or keyword is array, search for all keywords in all fields
             if (Array.isArray(config.search.field) || Array.isArray(config.search.keyword)) {
                 const searchFields = Array.isArray(config.search.field) ? config.search.field : [config.search.field];


### PR DESCRIPTION
## Context

Currently a lot of calls are being made on the PR tab page in the UI to: 
- `GET /pipelines/:id/events?count=1&page=1&prNum=prNum`
- `GET /jobs/:id/builds?count=10&page=1`
- `GET /events/:id/builds`

It would be nice if we could simplify these calls to get only latest builds in a PR and make fewer calls to the API.

## Objective

This PR adds a new flag `inverse` that will use `notILike` or `notLike` to search.

## References
Related to https://github.com/screwdriver-cd/screwdriver/pull/3078

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
