### PR TITLE
fix: bump mysql2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "joi": "^17.7.0",
-    "mysql2": "^2.3.3",
+    "mysql2": "^3.9.4",
     "pg": "^8.8.0",
     "pg-hstore": "^2.3.4",
     "screwdriver-data-schema": "^23.0.4",


### PR DESCRIPTION
## Context
The following vulnerability has been detected by Snyk.
https://www.cve.org/CVERecord?id=CVE-2024-21508
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We eliminate vulnerabilities.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
`sequelize` is compatible with the new `mysql2`
https://sequelize.org/docs/v6/other-topics/dialect-specific-things/#mysql
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
