### PR TITLE
feat(3163): Handle params with greater than or less than filter [1]

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -169,6 +169,8 @@ describe('index test', function () {
             or: 'OR',
             gte: 'GTE',
             lte: 'LTE',
+            gt: 'GT',
+            lt: 'LT',
             eq: 'EQ'
         };
         sequelizeMock.col = sinon.stub().returns('col');
@@ -1252,6 +1254,47 @@ describe('index test', function () {
                         name: 'foo',
                         id: {
                             IN: [1, 2, 3]
+                        }
+                    },
+                    order: [['id', 'DESC']]
+                });
+            });
+        });
+
+        it('scans for some data with params with inequality sign (gt or lt)', () => {
+            const testData = [
+                {
+                    id: 7,
+                    name: 'foo'
+                },
+                {
+                    id: 6,
+                    name: 'foo'
+                }
+            ];
+            const testInternal = [
+                {
+                    toJSON: sinon.stub().returns(testData[0])
+                },
+                {
+                    toJSON: sinon.stub().returns(testData[1])
+                }
+            ];
+
+            testParams.params = {
+                name: 'foo',
+                id: 'gt:5'
+            };
+
+            sequelizeTableMock.findAll.resolves(testInternal);
+
+            return datastore.scan(testParams).then(data => {
+                assert.deepEqual(data, testData);
+                assert.calledWith(sequelizeTableMock.findAll, {
+                    where: {
+                        name: 'foo',
+                        id: {
+                            GT: '5'
                         }
                     },
                     order: [['id', 'DESC']]


### PR DESCRIPTION
## Context

It would be nice if we could use the greater than or less than operators in our queries.

## Objective

This PR adds the `Sequelize.Op.gt` and `Sequelize.Op.lt` operators for query params (numbers only).

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/3163, https://sequelize.org/docs/v6/core-concepts/model-querying-basics/#operators

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
