### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-datastore-sequelize",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Datastore implementation for mysql, postgres, sqlite3, and mssql",
   "main": "index.js",
   "scripts": {
@@ -51,8 +51,8 @@
     "mysql2": "^3.9.4",
     "pg": "^8.8.0",
     "pg-hstore": "^2.3.4",
-    "screwdriver-data-schema": "^23.0.4",
-    "screwdriver-datastore-base": "^6.0.0",
+    "screwdriver-data-schema": "^24.0.0",
+    "screwdriver-datastore-base": "^7.0.0",
     "screwdriver-logger": "^2.0.0",
     "sequelize": "^6.27.0",
     "sqlite3": "^5.1.4"


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config

## Context

feat(3171): Move pipeline template workflowGraph out of config into a new field

## Objective

Upgrading dependencies

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
